### PR TITLE
Adding Uranus atmosphere

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -4003,7 +4003,7 @@
 		{
 			description = The seventh planet in our neighborhood, Uranus, named after the Greek god of the sky, is similar to the relatively nearby planet Neptune. Uranus is sometimes placed in a category separate from gas giants, known as "Ice Giants"mi. Having a similar atmosphere to Jupiter and Saturn, Uranus is different from the two gas giants in that it contains more water, ammonia and methane. It also has the coldest planetary atmosphere, somewhere around 49K.
 
-			radius = 25559000
+			radius = 24916000 // 25559000
 			mass = 8.681E+25
 			rotationPeriod = 62063.712
 			tidallyLocked = false
@@ -4081,15 +4081,101 @@
 		}
 		ScaledVersion
 		{
-			type = Vacuum
-			//fadeStart = 78000
-			//fadeEnd = 80000
+			type = Atmospheric
+			fadeStart = 300000
+			fadeEnd = 400000
 			Material
 			{
 				texture = RSS-Textures/UranusColor
 				normals = RSS-Textures/Flat_NRM
 				shininess = 0.01
 				specular = 0,0,0,1
+				
+				// Atmosphere settings
+				rimPower = 2.06
+				rimBlend = 0.3
+				
+				// Atmosphere color ramp texture
+				Gradient
+				{
+					0.0 = 0.094,0.220,0.643,1
+					0.6 = 0.0549,0.0784,0.141,1
+					1.0 = 0.0196,0.0196,0.0196,1
+				}
+			}
+		}
+		
+		Atmosphere
+		{
+			// effectively the ambient lighting color for all objects on the ground of this body (provides a slight tint)
+			ambientColor = 0.05,0.05,0.05,1
+
+			//
+			// shader.invWaveLength = Color( 1 / r^4, 1 / g^4, 1 / b^4, 0.5);
+			//
+			lightColor = 0.55, 0.44, 0.40, 1.0 // 0.65, 0.58, 0.5, 1.0
+
+			// General atmosphere settings
+			enabled = true
+			oxygen = false
+			maxAltitude = 900000
+
+			// Atmosphere Pressure
+			pressureCurve
+			{
+				key	=	200		353130.5397
+				key	=	400		351270.9242
+				key	=	600		349421.1015
+				key	=	800		347581.0202
+				key	=	1000	345750.6289
+				key	=	5000	311101.0533
+				key	=	10000	272630.6066
+				key	=	20000	209373.092
+				key	=	30000	160792.9945
+				key	=	40000	123484.7652
+				key	=	50000	94833.0322
+				key	=	60000	72829.25941
+				key	=	70000	55930.94414
+				key	=	80000	42953.48515
+				key	=	90000	32987.14003
+				key	=	100000	25333.25069
+				key	=	150000	6767.405574
+				key	=	200000	1807.812931
+				key	=	250000	482.9306533
+				key	=	300000	129.0078259
+				key	=	350000	34.46254453
+				key	=	400000	9.206162239
+				key	=	450000	2.45929093
+				key	=	500000	0.656963425
+				key	=	550000	0.175498123
+				key	=	600000	0.046881744
+				key	=	650000	0.012523769
+				key	=	700000	0.003345541
+				key	=	750000	0.000893712
+				key	=	800000	0.000238742
+				key	=	850000	6.37764E-05
+				key =	900000	0	0	0
+			}
+			// Atmosphere Temperature
+			temperatureCurve
+			{
+				key = 0 288.15 -0.0065 -0.0065
+				key = 11019.03 216.65 -0.006477574 0
+				key = 20062.98 216.65 0 0.0009937314
+				key = 32161.54 228.65 0.0009899797 0.002771943
+				key = 47349.3 270.65 0.00275884 0
+				key = 51411.55 270.65 0 -0.002755351
+				key = 71800.16 214.65 -0.00273794 -0.001955671
+				key = 85997.35 186.946 -0.001947081 0
+				key = 91289.6 186.946 0 0.0009719466
+				key = 114636.6 209.5563 0.0009649615 0.0009649615
+				key = 115529.4 210.4177 0.0009646959 0.0009646959
+				key = 180000 272.0002 0.0009458016 0.0009458016
+			}
+			AtmosphereFromGround
+			{
+				innerRadius = 24666840 // 0.99
+				outerRadius = 28653400 // 1.15
 			}
 		}
 	}


### PR DESCRIPTION
First of a new standard for gas giant atmospheres. (Surface moved to
approx where the pressure density is 1000 Bar)

Needs tweaking of appearance (around 300-400 above 'surface' the sky
should turn the same colour as the planet) and other colours for
consistency.

Atmosphere doesn't have tangent data for pressures or temperature data
(I am working on the temp data) yet.

My fiddling with Gradient, fadeStart and fadeEnd, and
AtmosphereFromGround did not seem to have the effect I intended, or any
at all.
