### PR TITLE
Neptune and Uranus

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -4113,12 +4113,12 @@
 			//
 			// shader.invWaveLength = Color( 1 / r^4, 1 / g^4, 1 / b^4, 0.5);
 			//
-			lightColor = 0.55, 0.44, 0.40, 1.0 // 0.65, 0.58, 0.5, 1.0
+			lightColor = 0.50, 0.44, 0.40, 1.0 // 0.65, 0.58, 0.5, 1.0
 
 			// General atmosphere settings
 			enabled = true
 			oxygen = false
-			maxAltitude = 900000
+			maxAltitude = 700000.0
 
 			// Atmosphere Pressure
 			pressureCurve
@@ -4159,18 +4159,38 @@
 			// Atmosphere Temperature
 			temperatureCurve
 			{
-				key = 0 288.15 -0.0065 -0.0065
-				key = 11019.03 216.65 -0.006477574 0
-				key = 20062.98 216.65 0 0.0009937314
-				key = 32161.54 228.65 0.0009899797 0.002771943
-				key = 47349.3 270.65 0.00275884 0
-				key = 51411.55 270.65 0 -0.002755351
-				key = 71800.16 214.65 -0.00273794 -0.001955671
-				key = 85997.35 186.946 -0.001947081 0
-				key = 91289.6 186.946 0 0.0009719466
-				key = 114636.6 209.5563 0.0009649615 0.0009649615
-				key = 115529.4 210.4177 0.0009646959 0.0009646959
-				key = 180000 272.0002 0.0009458016 0.0009458016
+				key	=	200		1038.710329
+				key	=	400		952.0669316
+				key	=	600		901.3837931
+				key	=	800		865.423534
+				key	=	1000	837.5305901
+				key	=	5000	636.3508511
+				key	=	10000	549.7074535
+				key	=	20000	463.0640559
+				key	=	30000	412.3809174
+				key	=	40000	376.4206584
+				key	=	50000	348.5277144
+				key	=	60000	325.7375198
+				key	=	70000	306.4686849
+				key	=	80000	289.7772608
+				key	=	90000	275.0543813
+				key	=	100000	261.8843169
+				key	=	150000	211.2011784
+				key	=	200000	175.2409193
+				key	=	250000	147.3479754
+				key	=	300000	124.5577808
+				key	=	350000	105.2889458
+				key	=	400000	88.59752174
+				key	=	450000	73.87464228
+				key	=	500000	60.70457782
+				key	=	550000	48.79080535
+				key	=	600000	37.91438323
+				key	=	650000	27.90904477
+				key	=	700000	18.64554825
+				key	=	750000	10.02143931
+				key	=	800000	1.954124169
+				key	=	850000	1.95
+				key	=	900000	1.95
 			}
 			AtmosphereFromGround
 			{
@@ -4207,7 +4227,7 @@
 		{
 			description = Neptune is the eighth and farthest planet from the Sun in the Solar System. It is the fourth-largest planet by diameter and the third-largest by mass. Among the gaseous planets in the Solar System, Neptune is the most dense. 
 
-			radius = 24622000
+			radius = 24272000 // adjusted below average to approximate height where pressure approaches 1000 Bar
 			mass = 1.0243E+26
 			rotationPeriod = 58000.32
 			tidallyLocked = false
@@ -4235,6 +4255,94 @@
 				normals = RSS-Textures/Flat_NRM
 				shininess = 0.01
 				specular = 0,0,0,1
+			}
+		}
+		Atmosphere
+		{
+			// effectively the ambient lighting color for all objects on the ground of this body (provides a slight tint)
+			ambientColor = 0.05,0.05,0.05,1
+
+			//
+			// shader.invWaveLength = Color( 1 / r^4, 1 / g^4, 1 / b^4, 0.5);
+			//
+			lightColor = 0.45, 0.56, 0.60, 1.0 // 0.65, 0.58, 0.5, 1.0
+
+			// General atmosphere settings
+			enabled = true
+			oxygen = false
+			maxAltitude = 700000.0
+
+			// Atmosphere Pressure
+			pressureCurve
+			{
+				key	=	200		353130.5397
+				key	=	400		351270.9242
+				key	=	600		349421.1015
+				key	=	800		347581.0202
+				key	=	1000	345750.6289
+				key	=	5000	311101.0533
+				key	=	10000	272630.6066
+				key	=	20000	209373.092
+				key	=	30000	160792.9945
+				key	=	40000	123484.7652
+				key	=	50000	94833.0322
+				key	=	60000	72829.25941
+				key	=	70000	55930.94414
+				key	=	80000	42953.48515
+				key	=	90000	32987.14003
+				key	=	100000	25333.25069
+				key	=	150000	6767.405574
+				key	=	200000	1807.812931
+				key	=	250000	482.9306533
+				key	=	300000	129.0078259
+				key	=	350000	34.46254453
+				key	=	400000	9.206162239
+				key	=	450000	2.45929093
+				key	=	500000	0.656963425
+				key	=	550000	0.175498123
+				key	=	600000	0.046881744
+				key	=	650000	0.012523769
+				key	=	700000	0.003345541
+				key	=	750000	0.000893712
+				key	=	800000	0.000238742
+				key	=	850000	6.37764E-05
+				key =	900000	0	0	0
+			}
+			// Atmosphere Temperature
+			temperatureCurve
+			{
+				key	=	200		1038.710329
+				key	=	400		952.0669316
+				key	=	600		901.3837931
+				key	=	800		865.423534
+				key	=	1000	837.5305901
+				key	=	5000	636.3508511
+				key	=	10000	549.7074535
+				key	=	20000	463.0640559
+				key	=	30000	412.3809174
+				key	=	40000	376.4206584
+				key	=	50000	348.5277144
+				key	=	60000	325.7375198
+				key	=	70000	306.4686849
+				key	=	80000	289.7772608
+				key	=	90000	275.0543813
+				key	=	100000	261.8843169
+				key	=	150000	211.2011784
+				key	=	200000	175.2409193
+				key	=	250000	147.3479754
+				key	=	300000	124.5577808
+				key	=	350000	105.2889458
+				key	=	400000	88.59752174
+				key	=	450000	73.87464228
+				key	=	500000	60.70457782
+				key	=	550000	48.79080535
+				key	=	600000	37.91438323
+				key	=	650000	27.90904477
+				key	=	700000	18.64554825
+				key	=	750000	10.02143931
+				key	=	800000	1.954124169
+				key	=	850000	1.95
+				key	=	900000	1.95
 			}
 		}
 	}


### PR DESCRIPTION
Both with temp and atmospheric pressure curves now!

Colours and atmospheric appearance on entry could probably use some
tweaking.

Neptune and Uranus are pretty similar, so these are basically the same
as each other. Good functional filler.

Planet radii adjusted to the radius at which atmospheric pressure is
approximately 1000 Bar (any probe will be crushed by this, even well
designed ones)
