### PR TITLE
RemoteTech_Settings added

### DIFF
--- a/GameData/RealSolarSystem/RemoteTech_Settings.cfg
+++ b/GameData/RealSolarSystem/RemoteTech_Settings.cfg
@@ -1,0 +1,438 @@
+RemoteTechSettings:NEEDS[RealSolarSystem]
+{
+	GroundStations
+	{
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc482
+			Name = AU - Woomera
+			Latitude = -30.95875
+			Longitude = 136.50366
+			Height = 417
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc483
+			Name = CN - Jiuquan
+			Latitude = 41.11803
+			Longitude = 100.4633
+			Height = 1350
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc484
+			Name = CN - Taiyuan
+			Latitude = 39.14321
+			Longitude = 111.96741
+			Height = 1750
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc485
+			Name = CN - Xichang
+			Latitude = 28.24646
+			Longitude = 102.02814
+			Height = 2150
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc486
+			Name = DZ - Hammaguir
+			Latitude = 30.77824
+			Longitude = -3.05377
+			Height = 994
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc487
+			Name = FR - Kourou
+			Latitude = 5.239380
+			Longitude = -52.768487
+			Height = 251
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc488
+			Name = IL - Palmachim
+			Latitude = 31.88484
+			Longitude = 34.6802
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc489
+			Name = IN - Satish Dhawan
+			Latitude = 13.72
+			Longitude = 80.230278
+			Height = 261
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48a
+			Name = IR - Semnan
+			Latitude = 35.234631
+			Longitude = 53.920941
+			Height = 1200
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48b
+			Name = JP - Tanegashima
+			Latitude = 30.39096
+			Longitude = 130.96813
+			Height = 275
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48c
+			Name = JP - Uchinoura
+			Latitude = 31.25186
+			Longitude = 131.07914
+			Height = 455
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48d
+			Name = KZ - Baikonur
+			Latitude = 45.920278
+			Longitude = 63.342222
+			Height = 340
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48e
+			Name = MH - Omelek
+			Latitude = 9.048167
+			Longitude = 167.743083
+			Height = 252
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc48f
+			Name = RU - Kapustin Yar
+			Latitude = 48.5400
+			Longitude = 46.2500
+			Height = 280
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc490
+			Name = RU - Plesetsk
+			Latitude = 62.957222
+			Longitude = 40.695833
+			Height = 380
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc491
+			Name = RU - Svobodny
+			Latitude = 51.83441
+			Longitude = 128.2757
+			Height = 500
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc492
+			Name = RU - Yasny
+			Latitude = 51.20706
+			Longitude = 59.85003
+			Height = 515
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc493
+			Name = US - Brownsville
+			Latitude = 25.996613
+			Longitude = -97.154206
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc494
+			Name = US - Cape Canaveral
+			Latitude = 28.608389
+			Longitude = -80.604333
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc495
+			Name = US - Kodiak
+			Latitude = 57.435276
+			Longitude = -152.339354
+			Height = 281
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc496
+			Name = US - Vandenberg
+			Latitude = 34.5813
+			Longitude = -120.6266
+			Height = 362
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc497
+			Name = US - Wallops
+			Latitude = 37.833755
+			Longitude = -75.458177
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc498
+			Name = MSTN - Bermuda (BDA)
+			Latitude = 32.352522
+			Longitude = -64.659222
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc499
+			Name = MSTN - Grand Canary Island (CAN)
+			Latitude = 27.956804
+			Longitude = -15.593948
+			Height = 260
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 7.5E+07
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc49a
+			Name = DSIF 11 - Goldstone (US)
+			Latitude = 35.389281
+			Longitude = -116.856197
+			Height = 1000
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 1E+12
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc49b
+			Name = DSIF 41 - Woomera (AU)
+			Latitude = -31.3822222
+			Longitude = 136.887778
+			Height = 1000
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 1E+12
+				}
+			}
+		}
+		STATION
+		{
+			Guid = 5105f5a9-d628-41c6-ad4b-21154e8fc49c
+			Name = DSIF 51 - Hartebeesthoek (SA)
+			Latitude = -25.887222
+			Longitude = 27.684722
+			Height = 1000
+			Body = 1
+			Antennas
+			{
+				ANTENNA
+				{
+					Omni = 1E+12
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added a RemoteTech_Settings file with only the ground stations. The module manager NEEDS-block should not be required, i only want to be safe.

Ref Task: https://github.com/RemoteTechnologiesGroup/RemoteTech/issues/490
Closes https://github.com/KSP-RO/RealismOverhaul/issues/519
