### PR TITLE
inspacelow/high border now at 2000km, no long 200km.

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -323,7 +323,7 @@
 			ScienceValues
 			{
 				flyingAltitudeThreshold = 22000
-				spaceAltitudeThreshold = 200000
+				spaceAltitudeThreshold = 2000000
 			}
 		}
 		ScaledVersion


### PR DESCRIPTION
With boundary for Mercury and Mars being 2000km I think 200km for Venus is inconsistent and probably a typo. 
