### PR TITLE
space low/high boundary raised for Venus & Gas Giants

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -323,7 +323,7 @@
 			ScienceValues
 			{
 				flyingAltitudeThreshold = 22000
-				spaceAltitudeThreshold = 200000
+				spaceAltitudeThreshold = 2000000
 			}
 		}
 		ScaledVersion
@@ -1837,7 +1837,7 @@
 			ScienceValues
 			{
 				flyingAltitudeThreshold = 186000
-				spaceAltitudeThreshold = 4000000
+				spaceAltitudeThreshold = 40000000
 			}
 		}
 		ScaledVersion
@@ -2629,7 +2629,7 @@
 			ScienceValues
 			{
 				flyingAltitudeThreshold = 410000
-				spaceAltitudeThreshold = 3000000
+				spaceAltitudeThreshold = 30000000
 			}
 			
 		}
@@ -4142,7 +4142,7 @@
 			ScienceValues
 			{
 				flyingAltitudeThreshold = 191000
-				spaceAltitudeThreshold = 3000000
+				spaceAltitudeThreshold = 30000000
 			}
 			
 		}


### PR DESCRIPTION
For scale: Mars has the boundary set to 4Mm, Mercury 2Mm. 200km for Venus is probably a mistake, increased to 2Mm.

The Gas Giants are 140, 120 and 50 Mm in diameter; the innermost moons are at 240Mm (Io/Jupiter) and 120Mm (Mimas/Saturn). Boundary at 4/3Mm seemed quite low, increased 10x.
