### PR TITLE
US_Kodiak fix

### DIFF
--- a/GameData/RealSolarSystem/LaunchSites.cfg
+++ b/GameData/RealSolarSystem/LaunchSites.cfg
@@ -486,11 +486,11 @@
 			}
 			PQSMod_MapDecalTangent
 			{
-				radius = 4080
-				heightMapDeformity = 80
+				radius = 10000
+				heightMapDeformity = 68
 				absoluteOffset = 50
 				absolute = true
-				latitude = 57.438276
+				latitude = 57.435276
 				longitude = -152.339354
 			}
 		}


### PR DESCRIPTION
I changed the radius, position and height of the MapDecalTangent at US Kodiak, so the Launch site isnt beneath the survice anymore. Runway may not be pointed straight east yet.
