### PR TITLE
vectors

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -2769,8 +2769,8 @@
 			Ring
 			{
 				angle = 0
-				outerRadius = 250
-				innerRadius = 125
+				outerRadius = 2500
+				innerRadius = 1250
 				texture = RSS-Textures/SaturnRing
 				color = 1,1,1,1
 				lockRotation = false

--- a/GameData/RealSolarSystem/RSSKopernicus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus.cfg
@@ -4380,7 +4380,7 @@
 				key	=	750000	0.000893712
 				key	=	800000	0.000238742
 				key	=	850000	6.37764E-05
-				key =	900000	0	0	0
+				key =	900000	0
 			}
 			// Atmosphere Temperature
 			temperatureCurve
@@ -4550,7 +4550,7 @@
 				key	=	750000	0.000893712
 				key	=	800000	0.000238742
 				key	=	850000	6.37764E-05
-				key =	900000	0	0	0
+				key =	900000	0
 			}
 			// Atmosphere Temperature
 			temperatureCurve


### PR DESCRIPTION
those two nodes are the only ones that have a mix of
''key'' with 2 elements and ''key'' with 4 elements

removing those two numbers will help with SigmaDimensions compatibility, but if you need those numbers for some weird reason feel free to delete this PR :)
