### PR TITLE
Triton Rotation

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
@@ -4,16 +4,16 @@
 {
 	@Body[Triton]
 	{
-	  @Properties // Triton rotationPeriod = -2 * pi * sqrt( SMA^3 / ( G * ( M + m )))
-	  {
-	    @tidallyLocked = false
-	    @rotationPeriod = #$gravParameter$
-	    @rotationPeriod += #$/Body[Neptune]/Properties/gravParameter$
-	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
-	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
-	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
-	    @rotationPeriod != -0.5
-	    @rotationPeriod *= -6.28318530717959
-	  }
-	}	
+		@Properties // Triton rotationPeriod = -2 * pi * sqrt( SMA^3 / ( G * ( M + m )))
+		{
+			@tidallyLocked = false
+			@rotationPeriod = #$gravParameter$
+			@rotationPeriod += #$/Body[Neptune]/Properties/gravParameter$
+			@rotationPeriod /= #$../Orbit/semiMajorAxis$
+			@rotationPeriod /= #$../Orbit/semiMajorAxis$
+			@rotationPeriod /= #$../Orbit/semiMajorAxis$
+			@rotationPeriod != -0.5
+			@rotationPeriod *= -6.28318530717959
+		}
+	}
 }

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
@@ -7,13 +7,14 @@
 		@Properties // Triton rotationPeriod = -2 * pi * sqrt( SMA^3 / ( G * ( M + m )))
 		{
 			@tidallyLocked = false
-			@rotationPeriod = #$gravParameter$
+			%rotationPeriod = #$gravParameter$
 			@rotationPeriod += #$/Body[Neptune]/Properties/gravParameter$
 			@rotationPeriod /= #$../Orbit/semiMajorAxis$
 			@rotationPeriod /= #$../Orbit/semiMajorAxis$
 			@rotationPeriod /= #$../Orbit/semiMajorAxis$
 			@rotationPeriod != -0.5
 			@rotationPeriod *= -6.28318530717959
+			@rotationPeriod:NEEDS[Principia] = -507760.19236393
 		}
 	}
 }

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton_Rotation.cfg
@@ -1,0 +1,19 @@
+// This will tidally lock Triton to Neptune
+
+@Kopernicus:FOR[RealSolarSystem]
+{
+	@Body[Triton]
+	{
+	  @Properties // Triton rotationPeriod = -2 * pi * sqrt( SMA^3 / ( G * ( M + m )))
+	  {
+	    @tidallyLocked = false
+	    @rotationPeriod = #$gravParameter$
+	    @rotationPeriod += #$/Body[Neptune]/Properties/gravParameter$
+	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
+	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
+	    @rotationPeriod /= #$../Orbit/semiMajorAxis$
+	    @rotationPeriod != -0.5
+	    @rotationPeriod *= -6.28318530717959
+	  }
+	}	
+}


### PR DESCRIPTION
This config will fix the rotation period of Triton in order to make it truly tidally locked

I have tested this a bit and wasn't able to find any issues in game.

I think however that someone else should test it as well, just to make sure I didn't miss anything.

As for my other modifications to RSS, I've put this on a separate cfg so that players may decide to "opt out" simply by deleting this one cfg.

EDIT:
added principia compatibility by using the rotationperiod calculated from here
http://astropedia.astrogeology.usgs.gov/download/Docs/WGCCRE/WGCCRE2009reprint.pdf
(only when principia is installed)
