### PR TITLE
Venus Rotation

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -36,7 +36,7 @@
 			ocean = false
 			// Stellar day.
 			solarRotationPeriod = False
-			rotationPeriod = 20996798.4
+			rotationPeriod = -20997360
 			rotates = true
 			initialRotation = 0
 			tidallyLocked = false

--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -36,7 +36,7 @@
 			ocean = false
 			// Stellar day.
 			solarRotationPeriod = False
-			rotationPeriod = -20997360
+			rotationPeriod = -20996797.016381
 			rotates = true
 			initialRotation = 0
 			tidallyLocked = false


### PR DESCRIPTION
This change is similar to pull request https://github.com/KSP-RO/RealSolarSystem/pull/79 if that turns out to work fine I think this should be fine as well.

<s>As a reference for the new rotationPeriod I used this site:
http://nssdc.gsfc.nasa.gov/planetary/factsheet/venusfact.html

the number turns out to be slightly different from the one previously used by RSS
if that number turns out to be more accurate you can always just make it negative and close this Pull Request</s>

changed reference to http://astropedia.astrogeology.usgs.gov/download/Docs/WGCCRE/WGCCRE2009reprint.pdf

per @eggrobin request

more specifically, venus rotation period was calculated using this value:
W = 160.20 **− 1.4813688d**

which is the rotation of venus in degrees during a period of 24hrs

rotP = (360 / -1.4813688) \* 24 \* 3600 = [deg]/([deg]/[day]) \* [s]/[day] = [seconds] 
