### PR TITLE
Moon: Use correct key for LAN

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -22,7 +22,7 @@
 			eccentricity = 0.05328149353682574
 			inclination = 28.36267790798491
 			meanAnomalyAtEpochD = 222.7012350930954
-			LAN = 2.296616161126016
+			longitudeOfAscendingNode = 2.296616161126016
 			argumentOfPeriapsis = 199.7640930160823
 			color = 1.0, 1.0, 1.0, 1.0
 		}


### PR DESCRIPTION
Fixes #102.  The longitude value is essentially arbitrary because the real Moon's orbit precesses too quickly, but we don't care.