### PR TITLE
Revert the obsolete workaround #112

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -38,7 +38,7 @@
 			tidallyLocked = true
 			initialRotation = 25
 			isHomeWorld = false
-			timewarpAltitudeLimits = 0 15000 30000 30000 100000 300000 600000 1000000
+			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/MoonBiomes.png
 


### PR DESCRIPTION
The timewarp altitude limit was raised in #112 to work around mockingbirdnest/Principia#1413, which manifested itself in RSS as #111. The latter issue was fixed with the release of Chasles, and, as discussed in https://github.com/KSP-RO/RealSolarSystem/issues/111#issuecomment-308180549, raising the altitude limit hampered usability. Reverting the obsolete workaround.