### PR TITLE
Modernize Custom Asteroids config

### DIFF
--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -1,25 +1,64 @@
 // Real Solar System Custom Asteroids Configuration
-// A modified version of excellent Basic Asteroids.cfg by Starstrider42
-// For Custom Asteroids 1.0+
+// For Custom Asteroids 1.3+
 // Compatible with Real Solar System v10.1+
 
-@AsteroidSets:FOR[RealSolarSystem]
+!AsteroidSets[CustomAsteroids_*]:FOR[RealSolarSystem] {}
+
+CustomAsteroidPlanes {
+	// From Souami & Souchay (2012), Astronomy & Astrophysics, 543, A133
+	// Converted to 1950 coordinates using HEASARC coordinate converter:
+	// http://heasarc.gsfc.nasa.gov/cgi-bin/Tools/convcoord/convcoord.pl
+	REFPLANE
+	{
+		name = rssInvariablePlane
+		// KSP coordinate system is equatorial B1950.0
+		longAscNode =  3.865539
+		inclination = 23.027637
+		// Keep the reference direction in the XZ plane
+		argReference = -4.200229
+	}
+}
+
+@CustomAsteroidPlanes:FOR[RealSolarSystem] {
+	%defaultRef = rssInvariablePlane
+}
+
+AsteroidSets
 {
-	!DEFAULT,*
-	{
-	}
-	!ASTEROIDGROUP,*
-	{
-	}
-	// Default block removed to prevent asteroid vacuum mode for Earth
-	// Stock intercept trajectories
-	// DEFAULT
+	name = RealSolarSystem_asteroids
+
+	// Intercept block removed to prevent asteroid vacuum mode for Earth
+	// INTERCEPT
 	// {
-	//	name = kerbinIntercept
-	//	 title = Potentially Hazardous Ast.
-	
-	//	//One incoming rock every 50 Earth days or 200 Kerbin days
-	//	 spawnRate = 0.02
+	// 	name = armAsteroids
+	// 	title = Pot. Hazard. Ast.
+	// 
+	// 	// One incoming rock every 25 Earth days
+	// 	spawnRate = 0.04
+	// 
+	// 	targetBody = Earth
+	// 
+	// 	approach
+	// 	{
+	// 		type = ImpactParameter
+	// 		dist = Uniform
+	// 		min = 0
+	// 		max = Ratio(Earth.soi, 1.0)
+	// 	}
+	// 
+	// 	warnTime
+	// 	{
+	// 		dist = Uniform
+	// 		min = Ratio(Earth.psol,  50)
+	// 		max = Ratio(Earth.psol, 220)
+	// 	}
+	// 
+	// 	vSoi
+	// 	{
+	// 		dist = Uniform
+	// 		min = Ratio(Earth.vorb, 0.01)
+	// 		max = Ratio(Earth.vorb, 0.05)
+	// 	}
 	// }
 
 	// NKO orbits based on NEO population from "Debiased Orbital and Absolute 
@@ -37,39 +76,39 @@
 
 		orbitSize
 		{
-			type = SemimajorAxis
-			min = Ratio(Kerbin.sma, 0.5 )
-			max = Ratio(  Jupiter.sma, 0.77)	// 4 AU, rescaled from Jupiter's to Jool's orbit
+			dist   = LogNormal
+			type   = SemimajorAxis		// Least correlated with eccentricity?
+			avg    = Ratio(Earth.sma, 1.8)
+			stddev = Ratio(Earth.sma, 0.5)
 		}
 
 		eccentricity
 		{
-			avg = 0.5
+			dist = Beta
+			avg = 0.58
+			stddev = 0.15
 		}
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.45
-			stddev = 4
+			avg = 7.5
 		}
-		
-		ascNode
+
+		asteroidTypes
 		{
-			dist = Gaussian
-			avg = 359.99
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
 		}
 	}
 
 	ASTEROIDGROUP
 	{
-		// Ignore Kirkwood gaps -- they won't have much of an impact on gameplay
 		name = MainBeltZoneI
 		title = Zone I Main Belt Ast. 
 
 		centralBody = Sun
 
-		// With default lifetime settings, 5.3 asteroids will be around on average
 		spawnRate = 0.6
 
 		orbitSize
@@ -86,27 +125,25 @@
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.44
-			stddev = 10
+			avg = 7.5
 		}
-		
-		ascNode
+
+		asteroidTypes
 		{
-			dist = Gaussian
-			avg = 3.31
+			// Composition based on Mothé-Diniz et al. (2003), Icarus, 162, 10
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
 		}
 	}
 	
 	ASTEROIDGROUP
 	{
-		// Ignore Kirkwood gaps -- they won't have much of an impact on gameplay
 		name = MainBeltZoneII
 		title = Zone II Main Belt Ast.
 
 		centralBody = Sun
 
-		// With default lifetime settings, 5.3 asteroids will be around on average
 		spawnRate = 0.45
 
 		orbitSize
@@ -123,27 +160,25 @@
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.44
-			stddev = 10
+			avg = 7.5
 		}
-		
-		ascNode
+
+		asteroidTypes
 		{
-			dist = Gaussian
-			avg = 3.31
+			// Composition based on Mothé-Diniz et al. (2003), Icarus, 162, 10
+			key = 0.60 PotatoRoid
+			key = 0.30 CaAsteroidCarbon
+			key = 0.10 CaAsteroidMetal
 		}
 	}
 	
 	ASTEROIDGROUP
 	{
-		// Ignore Kirkwood gaps -- they won't have much of an impact on gameplay
 		name = MainBeltZoneIII
 		title = Zone III Main Belt Ast.
 
 		centralBody = Sun
 
-		// With default lifetime settings, 5.3 asteroids will be around on average
 		spawnRate = 0.2
 
 		orbitSize
@@ -160,15 +195,17 @@
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.44
-			stddev = 10
+			avg = 7.5
 		}
-		
-		ascNode
+
+		asteroidTypes
 		{
-			dist = Gaussian
-			avg = 3.31
+			// Composition based on Mothé-Diniz et al. (2003), Icarus, 162, 10
+			key = 0.10 PotatoRoid
+			key = 0.79 CaAsteroidCarbon
+			key = 0.10 CaAsteroidMetal
+			// Why not add some main belt comets?
+			key = 0.01 CaCometActive
 		}
 	}
 	
@@ -198,27 +235,24 @@
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.25	// For now, just merge the low- and high-inclination groups together
-			stddev = 4
+			avg = 13	// For now, just merge the low- and high-inclination groups together
 		}
 
-		ascNode
-		{
-			dist = Gaussian
-			avg = 3.26
-		}
-		
 		orbitPhase
 		{
 			type   = MeanLongitude
 			epoch  = GameStart
 			dist   = Gaussian
-			avg    = Offset(Jupiter.mnl0, 180)
-			// Real Trojan belts have a standard deviation of 13 degrees in longitude, 
+			avg    = Offset(Jupiter.mnl0, 60)
+			// Real Trojan belts have a standard deviation of 13 degrees in true longitude, 
 			// but I'm assuming a lot of that is from inclination. Allow +/- 10 degree 
-			// variation in longitude instead
+			// variation in mean longitude
 			stddev = 10
+		}
+
+		asteroidTypes
+		{
+			key = 1.0 CaAsteroidCarbon
 		}
 	}
 
@@ -245,15 +279,7 @@
 
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.25	// For now, just merge the low- and high-inclination groups together
-			stddev = 4
-		}
-
-		ascNode
-		{
-			dist = Gaussian
-			avg = 3.26
+			avg = 13	// For now, just merge the low- and high-inclination groups together
 		}
 
 		orbitPhase
@@ -261,8 +287,13 @@
 			type  = MeanLongitude
 			epoch = GameStart
 			dist = Gaussian
-			avg    = Offset(Jupiter.mnl0, 60)
+			avg    = Offset(Jupiter.mnl0, -60)
 			stddev = 10
+		}
+
+		asteroidTypes
+		{
+			key = 1.0 CaAsteroidCarbon
 		}
 	}
 
@@ -275,7 +306,7 @@
 
 		centralBody = Sun
 
-		// One comet every 20 Earth days (80 Kerbin days)
+		// One comet every 20 Earth days
 		spawnRate = 0.05
 
 		orbitSize
@@ -283,13 +314,13 @@
 			type = Periapsis
 			//min =   261600000	// Sungrazers
 			min = Ratio(Mercury.sma, 0.2)
-			max = Ratio(Jupiter.sma, 1.0)	// Ignore comets outside the orbit of Jool
+			max = Ratio(Jupiter.sma, 1.0)	// Ignore comets outside the orbit of Jupiter
 		}
 
 		eccentricity
 		{
 			dist = Uniform
-			min = 0.98		// Minimum apoapsis: 1.7× Jool's orbit
+			min = 0.98		// Minimum apoapsis: 1.7× Jupiter's orbit
 			max = 1.005
 		}
 
@@ -307,6 +338,11 @@
 			min = -2.0	// Extremely elliptical orbit; little time spent near periapsis
 			max = -0.1
 		}
+
+		asteroidTypes
+		{
+			key = 1.0 CaCometActive
+		}
 	}
 	
 	ASTEROIDGROUP
@@ -314,12 +350,11 @@
 		// Plutinos based on Wikipedia article, plans to refine their orbits with better information
 		// in the future
 		name = Plutinos
-		title = Plutino Ast. 
+		title = Plutino KBO
 
 		centralBody = Sun
 
-		// With default lifetime settings, 4.8 Trojans will be around on average
-		spawnRate = 0.5
+		spawnRate = 0.5		// 25% of Kuiper belt objects are Plutinos
 
 		orbitSize
 		{
@@ -330,28 +365,25 @@
 
 		eccentricity
 		{
-			dist = Uniform
-			min = 0.2
-			max = 0.25
+			avg = 0.16
 		}
 
 		inclination
 		{
-			dist = Gaussian
-			avg = Ratio(Pluto.inc,1)
-			stddev = 8
-		}
-		
-		periapsis
-		{
-			min = Ratio(Pluto.ape,1)
-			max = Ratio(Pluto.ape,1)
+			avg = 7
 		}
 
-		ascNode
+		// Not sure if this is still needed -- Starstrider42
+		// periapsis
+		// {
+		// 	min = Ratio(Pluto.ape,1)
+		// 	max = Ratio(Pluto.ape,1)
+		// }
+
+		asteroidTypes
 		{
-			min = Ratio(Pluto.lan,0.995)
-			max = Ratio(Pluto.lan,1.005)
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
 		}
 	}
 	
@@ -364,33 +396,29 @@
 		
 		centralBody = Sun
 		
-		spawnRate = 1.5
+		spawnRate = 1.5		// 75% of Kuiper belt objects are NOT Plutinos
 		
 		orbitSize
 		{
-			type = Periapsis
-			min = 6.283110569e+12
-			max = 7.180697793e+12
+			type = SemimajorAxis
+			min  = Resonance(Neptune, 2:3)
+			max  = Resonance(Neptune, 1:2)
 		}
 		
 		eccentricity
 		{
-			dist = LogUniform
-			min = 0.000001
-			max = 0.1
+			avg = 0.16
 		}
-		
+
 		inclination
 		{
-			dist = Gaussian
-			avg = 23.25	// For now, just merge the low- and high-inclination groups together
-			stddev = 4
+			avg = 7
 		}
-		
-		ascNode
+
+		asteroidTypes
 		{
-			dist = Gaussian
-			avg = 3.26
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
 		}
 	}	
 }

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -2,6 +2,7 @@
 // For Custom Asteroids 1.3.1+
 // Compatible with Real Solar System v10.1+
 
+// Prevent accidentally installed stock configs from interfering
 !AsteroidSets[CustomAsteroids_*]:FOR[RealSolarSystem] {}
 
 CustomAsteroidPlanes {
@@ -71,8 +72,8 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 3.2 NKOs will be around on average
-		spawnRate = 0.3
+		// With default lifetime settings, 1.6 NKOs will be around on average
+		spawnRate = 0.15
 
 		orbitSize
 		{
@@ -109,7 +110,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.6
+		spawnRate = 0.3
 
 		orbitSize
 		{
@@ -144,7 +145,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.45
+		spawnRate = 0.22
 
 		orbitSize
 		{
@@ -179,7 +180,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.2
+		spawnRate = 0.1
 
 		orbitSize
 		{
@@ -218,8 +219,8 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 4.8 Trojans will be around on average
-		spawnRate = 0.23
+		// With default lifetime settings, 2.4 Trojans will be around on average
+		spawnRate = 0.11
 
 		orbitSize
 		{
@@ -263,7 +264,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.23
+		spawnRate = 0.11
 
 		orbitSize
 		{
@@ -297,8 +298,6 @@ AsteroidSets
 		}
 	}
 
-	// Long-period comets only; short-period comets depend on the location 
-	// of the scattered disk
 	ASTEROIDGROUP
 	{
 		name = oort
@@ -306,8 +305,8 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// One comet every 20 Earth days
-		spawnRate = 0.05
+		// One comet every 40 Earth days
+		spawnRate = 0.025
 
 		orbitSize
 		{
@@ -354,7 +353,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.5		// 25% of Kuiper belt objects are Plutinos
+		spawnRate = 0.12		// 25% of Kuiper belt objects are Plutinos
 
 		orbitSize
 		{
@@ -396,7 +395,7 @@ AsteroidSets
 		
 		centralBody = Sun
 		
-		spawnRate = 1.5		// 75% of Kuiper belt objects are NOT Plutinos
+		spawnRate = 0.38		// 75% of Kuiper belt objects are NOT Plutinos
 		
 		orbitSize
 		{
@@ -429,9 +428,9 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// Very hard to find: 100 Earth days between discoveries
-		// With default lifetime settings, an SDO will be visible 9.5% of the time
-		spawnRate = 0.01
+		// Very hard to find: 200 Earth days between discoveries
+		// With default lifetime settings, an SDO will be visible 5.11% of the time
+		spawnRate = 0.005
 
 		orbitSize
 		{
@@ -473,8 +472,8 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 0.5 centaurs will be around on average
-		spawnRate = 0.05
+		// With default lifetime settings, 0.3 centaurs will be around on average
+		spawnRate = 0.025
 
 		orbitSize
 		{
@@ -509,7 +508,7 @@ AsteroidSets
 		centralBody = Sun
 
 		// With default lifetime settings, 1.1 comets will be around on average
-		spawnRate = 0.1
+		spawnRate = 0.05
 
 		orbitSize
 		{
@@ -545,7 +544,7 @@ AsteroidSets
 		centralBody = Sun
 
 		// With default lifetime settings, 1.1 comets will be around on average
-		spawnRate = 0.1
+		spawnRate = 0.05
 
 		orbitSize
 		{

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -1,5 +1,5 @@
 // Real Solar System Custom Asteroids Configuration
-// For Custom Asteroids 1.3+
+// For Custom Asteroids 1.3.1+
 // Compatible with Real Solar System v10.1+
 
 !AsteroidSets[CustomAsteroids_*]:FOR[RealSolarSystem] {}
@@ -420,5 +420,156 @@ AsteroidSets
 			key = 0.10 CaAsteroidCarbon
 			key = 0.90 CaAsteroidIcy
 		}
-	}	
+	}
+
+	ASTEROIDGROUP
+	{
+		name = sdo
+		title = Scattered Disk Obj.
+
+		centralBody = Sun
+
+		// Very hard to find: 100 Earth days between discoveries
+		// With default lifetime settings, an SDO will be visible 9.5% of the time
+		spawnRate = 0.01
+
+		orbitSize
+		{
+			type = Periapsis
+			min  = Ratio(Neptune.apo, 1.0)	// ~30 AU
+			max  = Ratio(Neptune.apo, 1.6)	// ~50 AU
+		}
+
+		eccentricity
+		{
+			avg = 0.5
+		}
+
+		inclination
+		{
+			avg = 15
+		}
+
+		orbitPhase			// Typically visible near periapsis
+		{
+			type   = MeanAnomaly
+			epoch  = Now
+			dist   = Gaussian
+			avg    = 0
+			stddev = 10
+		}
+
+		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = centaurs
+		title = Centaur
+
+		centralBody = Sun
+
+		// With default lifetime settings, 0.5 centaurs will be around on average
+		spawnRate = 0.05
+
+		orbitSize
+		{
+			type = SemimajorAxis
+			min  = Ratio(Jupiter.sma, 1.8)	// T_J >~ 3
+			max  = Ratio(Neptune.sma, 0.8)	// Minimize overlap with periodic comets
+		}
+
+		eccentricity
+		{
+			avg = 0.35
+		}
+
+		inclination
+		{
+			avg = 22
+		}
+
+		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.70 CaAsteroidIcy
+			key = 0.20 CaCometActive
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = midComets
+		title = Periodic Cmt.
+
+		centralBody = Sun
+
+		// With default lifetime settings, 1.1 comets will be around on average
+		spawnRate = 0.1
+
+		orbitSize
+		{
+			type = Apoapsis
+			min  = Ratio(Jupiter.sma, 2.4)	// Separate from Jupiter-family
+			max  = Ratio(Neptune.apo, 1.6)	// Comets come from scattered disk...
+		}
+
+		eccentricity
+		{
+			dist = Uniform
+			min  = 0.7		// W/ apoapsis constraint, gives periapsis inside Jupiter
+			max  = 0.99999
+		}
+
+		inclination
+		{
+			avg = 30
+		}
+
+		asteroidTypes
+		{
+			key = 0.20 CaAsteroidCarbon
+			key = 0.80 CaCometActive
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = jupiterComets
+		title = Jupiter-Family Cmt.
+
+		centralBody = Sun
+
+		// With default lifetime settings, 1.1 comets will be around on average
+		spawnRate = 0.1
+
+		orbitSize
+		{
+			type = SemimajorAxis
+			min  = Ratio(Jupiter.sma, 0.7)		// T_J <~ 3
+			max  = Ratio(Jupiter.sma, 1.4)		// Period of < 20 years
+		}
+
+		eccentricity
+		{
+			dist = Gaussian
+			avg    = 0.5
+			stddev = 0.18
+		}
+
+		inclination
+		{
+			avg = 13
+		}
+
+		asteroidTypes
+		{
+			key = 0.25 CaAsteroidCarbon
+			key = 0.75 CaCometActive
+		}
+	}
 }


### PR DESCRIPTION
This PR updates `Compatibility/CustomAsteroids.cfg` to fix a number of bugs in the old config and to add support for features introduced in Custom Asteroids 1.3 and later. Specifically, it fixes the following issues:
- RSS-compatible asteroids are their own `AsteroidSets` block rather than an MM patch. The patch had unpredictable behavior because it relied on the player having exactly one non-RSS asteroid config installed, when in practice they could have zero to three. MM is still used to suppress stock configs, in case they are installed by accident.
- The new config uses the `CustomAsteroidPlanes` feature to define all orbital properties relative to the solar system's invariable plane. Configs no longer need to hack the asteroids' ascending node and inclination to get a rough alignment. (The new system works quite nicely; see screenshot)
- Spawn rates have been scaled down to generate ~20 untracked asteroids with default lifetime settings, reducing both lag and tracking station spam. Lag can be further reduced by forcing a longer lifetime and reducing spawn rates accordingly; since this requires changing what should be a user setting, I feel it's outside my authority to propose that.
- Support for a few more outer solar system populations (scattered disk, centaurs, periodic comets).
- Support for asteroids with different compositions (resources) and science text.

![screenshot0](https://user-images.githubusercontent.com/6760782/36187244-adc83dcc-10f8-11e8-8a03-bace236b185f.png)
