### PR TITLE
[Bug Fix] Asteroid mass & size fixes

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Asteroids/Asteroids.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Asteroids/Asteroids.cfg
@@ -13,7 +13,7 @@
 
 //  Sources:
 
-//  On the asteroid belt’s orbital and size distribution: http://orbit.psi.edu/~tricaric/pdf/skads.pdf
+//  Ikarus - On the asteroid belt’s orbital and size distribution: http://orbit.psi.edu/~tricaric/pdf/skads.pdf
 
 //  Notes:
 
@@ -32,7 +32,7 @@
         probability = 66
         minUntrackedLifetime = 1
         maxUntrackedLifetime = 20
-        spawnGroupMinLimit = 3
+        spawnGroupMinLimit = 4
         spawnGroupMaxLimit = 8
 
         Locations
@@ -43,7 +43,7 @@
                 {
                     body = Sun
                     probability = 50
-                    reached = false
+                    reached = False
 
                     semiMajorAxis
                     {
@@ -91,7 +91,7 @@
                     probability = 50
                     minDuration = 15
                     maxDuration = 60
-                    reached = false
+                    reached = False
                 }
             }
         }
@@ -103,5 +103,31 @@
             key = 0.7 0.55
             key = 1   1
         }
+    }
+}
+
+//  ==================================================
+//  Asteroid properties.
+
+//  Sources:
+
+//  LPI - Asteroid Density, Porosity & Structure: https://www.lpi.usra.edu/books/AsteroidsIII/pdf/3022.pdf
+
+//  Notes:
+
+//  * Density is defined as the average density of both
+//    the three main material categories (clays, silicates
+//    and nickel-iron) compared to the average bulk density
+//    of some well-known asteroids.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleAsteroid]]:FOR[RealSolarSystem]
+{
+    @MODULE[ModuleAsteroid]
+    {
+        @density = 3.3456
+        @secondaryRate = 0.001
+        %minRadiusMultiplier = 10.0
+        %maxRadiusMultiplier = 100.0
     }
 }


### PR DESCRIPTION
**Change Log:**

* Fix the density and size of the RSS asteroids (were still at stock stats).

**Notes:**

* The stock KSP "rendezvous" function will break, since the average radius of the larger asteroid categories (E, D and probably C) is larger than the maximum distance that KSP "hyperedits" a vessel (150 meters). This will cause the vessel to be positioned inside the asteroid, destroying or accelerating it at high speeds upon physics loading.