### PR TITLE
[Feature] RSS CommNet ground stations

### DIFF
--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -1,0 +1,1757 @@
+//  ==================================================
+//  Add custom CommNet stations for Real Solar System.
+//  ==================================================
+
+@Kopernicus:AFTER[RealSolarSystem]
+{
+    @Body[Kerbin]
+    {
+        @PQS
+        {
+            @Mods
+            {
+                !City2,*{}
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = AU - Woomera
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -30.95875
+                    lon = 136.50366
+                    alt = 417
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = CN - Jiuquan
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 41.11803
+                    lon = 100.4633
+                    alt = 1350
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = CN - Taiyuan
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 39.14321
+                    lon = 111.96741
+                    alt = 1750
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = CN - Wenchang
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 19.614492
+                    lon = 110.951133
+                    alt = 10
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = CN - Xichang
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 28.24646
+                    lon = 102.02814
+                    alt = 2150
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = DZ - Hammaguir
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 30.77824
+                    lon = -3.05377
+                    alt = 994
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = FR - Kourou
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 5.239380
+                    lon = -52.768487
+                    alt = 251
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = IL - Palmachim
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 31.88484
+                    lon = 34.6802
+                    alt = 260
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = IN - Satish Dhawan
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 13.72
+                    lon = 80.230278
+                    alt = 261
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = IR - Semnan
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 35.234631
+                    lon = 53.920941
+                    alt = 1200
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = JP - Tanegashima
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 30.39096
+                    lon = 130.96813
+                    alt = 275
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = JP - Uchinoura
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 31.25186
+                    lon = 131.07914
+                    alt = 455
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = KZ - Baikonur
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 45.920278
+                    lon = 63.342222
+                    alt = 340
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = MH - Omelek
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 9.048167
+                    lon = 167.743083
+                    alt = 252
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = RU - Kapustin Yar
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 48.5400
+                    lon = 46.2500
+                    alt = 280
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = RU - Plesetsk
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 62.957222
+                    lon = 40.695833
+                    alt = 380
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = RU - Svobodny
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 51.83441
+                    lon = 128.2757
+                    alt = 500
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = RU - Yasny
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 51.20706
+                    lon = 59.85003
+                    alt = 515
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - Brownsville
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 25.996613
+                    lon = -97.154206
+                    alt = 260
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - Cape Canaveral
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 28.608389
+                    lon = -80.604333
+                    alt = 260
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - Kodiak
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 57.435276
+                    lon = -152.339354
+                    alt = 281
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - Vandenberg
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 34.5813
+                    lon = -120.6266
+                    alt = 362
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - Wallops
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 37.833755
+                    lon = -75.458177
+                    alt = 260
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = 11.3 M - WGS Wallops
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 37.9346354
+                    lon = -75.4715983
+                    alt = 20
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = AGO 4 - SSC Santiago
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -33.1505697
+                    lon = -70.6686904
+                    alt = 730
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = AS3 - ASF Fairbanks
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 64.8592873
+                    lon = -147.8515734
+                    alt = 135
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = AUWA01 - USN South Point
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 19.0138554
+                    lon = -155.6635408
+                    alt = 370
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSA 1 - New Norcia
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -31.048986
+                    lon = 116.1907166
+                    alt = 252
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSA 2 - Cebreros
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 40.452592
+                    lon = -4.3686749
+                    alt = 795
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSA 3 - Malargüe
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -35.7762392
+                    lon = -69.3990988
+                    alt = 1550
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSS 14 - Goldstone
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 35.4251262
+                    lon = -116.8913795
+                    alt = 900
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSS 43 - Canberra
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -35.4006289
+                    lon = 148.9790935
+                    alt = 555
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DSS 63 - Madrid
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 40.4273387
+                    lon = -4.2519912
+                    alt = 725
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = DON - USN Dongara
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -29.0453159
+                    lon = 115.350711
+                    alt = 40
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Ascension
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -7.968795
+                    lon = -14.405333
+                    alt = 251
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Galliot
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 5.097918
+                    lon = -52.639726
+                    alt = 251
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Kourou
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 5.2512859
+                    lon = -52.8051729
+                    alt = 15
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Libreville
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 0.374595
+                    lon = 9.640953
+                    alt = 251
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Malindi
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -2.9959517
+                    lon = 40.1943803
+                    alt = 25
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Maspalomas
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 27.7632619
+                    lon = -15.6330766
+                    alt = 205
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Natal
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -5.925
+                    lon = -35.163056
+                    alt = 251
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Perth
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -31.8027436
+                    lon = 115.8841403
+                    alt = 25
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Redu
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 50.0013995
+                    lon = 5.1448218
+                    alt = 387
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Santa Maria
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 36.9971801
+                    lon = -25.1372121
+                    alt = 276
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = ESTRACK - Villafranca
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 40.4423327
+                    lon = -3.9524855
+                    alt = 670
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = HBK - SANSA Hartebeesthoek
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -25.8904984
+                    lon = 27.6851873
+                    alt = 1570
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = KIR 1 - SSC Kiruna
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 67.8926896
+                    lon = 21.0560142
+                    alt = 417
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MGS - MGS McMurdo
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -77.8386694
+                    lon = 166.6625901
+                    alt = 50
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - BDA Bermuda
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 32.3549
+                    lon = -64.6605
+                    alt = 135
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - CAN Grand Canary
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 28.0068
+                    lon = -15.5984
+                    alt = 300
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - GUY Guaymas Mexico
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 27.911140
+                    lon = -110.913240
+                    alt = 300
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - HAW Kauai Hawaii
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 22.060649
+                    lon = -159.532340
+                    alt = 5000
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - IOS Indian Ocean
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 28.0
+                    lon = 78.35
+                    alt = 0.0
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - KAN Kano Nigeria
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 11.999867
+                    lon = 8.537112
+                    alt = 5000
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = MSFN - POS Pacific Ocean
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 0.0
+                    lon = 177.0
+                    alt = 0.0
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = SG3 - KSAT Svalbard
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 69.6617869
+                    lon = 18.940005
+                    alt = 500
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = SGLT 1 - WSGT White Sands
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 32.4998826
+                    lon = -106.6095675
+                    alt = 1200
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = SGLT 6 - GRGT Guam
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 13.5876921
+                    lon = 144.8386329
+                    alt = 45
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = TR3 - KSAT Troll Station
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -72.0113947
+                    lon = 2.541923
+                    alt = 1300
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = GenericTrackingStation
+                    objectName = WAL - USN Weilheim
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 47.8817101
+                    lon = 11.0806729
+                    alt = 417
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -1527,7 +1527,7 @@
                     isKSC = False
                     commnetStation = True
                     snapToSurface = True
-                    lat = 28.0
+                    lat = -28.0
                     lon = 78.35
                     alt = 0.0
                     snapHeightOffset = 0


### PR DESCRIPTION
**Change Log:**

* Add custom CommNet stations mirroring the RemoteTech ones.

**Notes:**

* There is a minor Kopernicus bug where the name of the station that a vessel is currently connected to will be blank. This is just a UI error.
* ~~The extra stock KSP ground stations are still present.~~