### PR TITLE
[Maintenance] Remove unnecessary PQS mods

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -11,7 +11,7 @@
 		Template
 		{
 			name = Kerbin
-			removePQSMods = PQSCity[IslandAirfield], PQSCity[KSC2], PQSCity[Monolith00], PQSCity[Monolith01], PQSCity[Monolith02], PQSCity[Monolith03], PQSCity[Pyramids], PQSCity[Randolith], PQSCity[UFO], PQSCity2, PQSLandControl, PQSMod_VertexSimplexHeightAbsolute, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_VertexRidgedAltitudeCurve
+			removePQSMods = PQSCity[IslandAirfield], PQSCity[Monolith00], PQSCity[Monolith01], PQSCity[Monolith02], PQSCity[Monolith03], PQSCity[Pyramids], PQSCity[Randolith], PQSCity[UFO], PQSCity2, PQSLandControl, PQSMod_VertexSimplexHeightAbsolute, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_VertexRidgedAltitudeCurve
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -11,7 +11,7 @@
 		Template
 		{
 			name = Kerbin
-			removePQSMods = PQSLandControl, PQSMod_VertexSimplexHeightAbsolute, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_VertexRidgedAltitudeCurve
+			removePQSMods = PQSCity[IslandAirfield], PQSCity[KSC2], PQSCity[Monolith00], PQSCity[Monolith01], PQSCity[Monolith02], PQSCity[Monolith03], PQSCity[Pyramids], PQSCity[Randolith], PQSCity[UFO], PQSCity2, PQSLandControl, PQSMod_VertexSimplexHeightAbsolute, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_VertexRidgedAltitudeCurve
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters, PQSMod_FlattenArea, PQSMod_VertexHeightNoiseVertHeight,  PQSMod_AltitudeAlpha
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_AltitudeAlpha, PQSMod_VoronoiCraters, PQSMod_FlattenArea, PQSMod_VertexHeightNoiseVertHeight
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Europa.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Europa.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSMod_AltitudeAlpha, PQSLandControl, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSMod_AltitudeAlpha, PQSLandControl, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Ganymede.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Ganymede.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSMod_AltitudeAlpha, PQSLandControl, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters, PQSMod_FlattenArea, PQSMod_VertexHeightNoiseVertHeight,  PQSMod_AltitudeAlpha
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_AltitudeAlpha, PQSMod_VoronoiCraters, PQSMod_FlattenArea, PQSMod_VertexHeightNoiseVertHeight
 		}
 
 		Orbit

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Charon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Charon.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		SigmaBinary
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSMod_AltitudeAlpha, PQSLandControl, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSMod_AltitudeAlpha, PQSLandControl, PQSMod_FlattenArea, PQSMod_VertexSimplexNoiseColor, PQSMod_VertexSimplexHeight, PQSMod_VertexHeightNoiseVertHeight, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Dione.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Dione.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Enceladus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Enceladus.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Iapetus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Iapetus.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Mimas.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Mimas.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Rhea.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Rhea.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Tethys.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Tethys.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Mun
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{

--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -10,7 +10,7 @@
 		Template
 		{
 			name = Duna
-			removePQSMods = PQSLandControl, PQSMod_VoronoiCraters, PQSMod_FlattenArea, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_MapDecal, PQSMod_AltitudeAlpha
+			removePQSMods = PQSCity, PQSLandControl, PQSMod_AltitudeAlpha, PQSMod_FlattenArea, PQSMod_MapDecal, PQSMod_VertexHeightNoiseVertHeightCurve2, PQSMod_VoronoiCraters
 		}
 		Orbit
 		{


### PR DESCRIPTION
**Change Log:**

* Remove unnecessary PQSMods from all applicable bodies.
* Remove the extra stock CommNet stations appearing on the Earth.

**Notes:**

* The KSC2 ("Baikerbanur") is not removed by the above patches because of some CommNet issues.