### PR TITLE
[Maintenance] RSS Kopernicus settings updates

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicusSettings.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicusSettings.cfg
@@ -1,10 +1,14 @@
 @Kopernicus:FOR[RealSolarSystem]
 {
 	@name = Solar System
-	useOnDemand = false
-	onDemandLoadOnMissing = true
-	onDemandLogOnMissing = false
-	onDemandForceCollect = false
+	%useOnDemand = True
+	%onDemandLoadOnMissing = True
+	%onDemandLogOnMissing = False
+	%onDemandForceCollect = False
+
+	// Remove all stock launch sites.
+
+	%removeLaunchSites = Desert_Airfield, Desert_GroundObjects, Desert_Launch_Site, Island_Airfield, Woomerang_GroundObjects, Woomerang_Launch_Site
 	
 	// Form: Epoch is the time in seconds until the epoch of orbital elements.
 	// We use B1950.0 == 1949-12-31 22:09:18.216 Temps Atomique International.
@@ -13,6 +17,7 @@
 	// starts (We do *not* use UTC because leap seconds are discontinuous, and UTC
 	// is not defined in 1951; UT1 is a right mess).
 	// The time to epoch was computed as -(365*24*3600 + 24*3600 - 22*3600 - 9*60 - 18.216).
+
 	Epoch = -31542641.784 
 	
 	// The orbital elements are computed using the Jet Propulsion Laboratory


### PR DESCRIPTION
**Change log:**

* ~~Fully enable the Kopernicus OnDemand feature (dynamic loading and unloading of the RSS textures).~~
* Remove all alternate stock launch sites introduced with the Making History DLC (launch sites are managed by KSCSwitcher).