### PR TITLE
Additional tracking stations for RA

### DIFF
--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -679,6 +679,383 @@
                     }
                 }
 
+				City2
+                {
+                    name = STDNTrackingStation
+                    objectName = STDN - Quito
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -0.6228083333
+                    lon = -78.5802
+                    alt = 3545
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = STDNTrackingStation
+                    objectName = STDN - Ascension
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -7.955288889
+                    lon = -14.32757778
+                    alt = 544
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = STDNTrackingStation
+                    objectName = STDN - Johannesburg
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -25.88587778
+                    lon = 27.70775833
+                    alt = 1537
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = STDNTrackingStation
+                    objectName = STDN - Tananarive
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -19.000275
+                    lon = 47.31505278
+                    alt = 1338
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = STDNTrackingStation
+                    objectName = STDN - Carnarvon
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -24.90761944
+                    lon = 113.7242139
+                    alt = 55
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = MSFNTrackingStation
+                    objectName = MSFN - Kauai
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 22.12618333
+                    lon = -159.6651944
+                    alt = 1131
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+				City2
+                {
+                    name = MSFNTrackingStation
+                    objectName = MSFN - Guaymas
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 27.962975
+                    lon = -110.7211722
+                    alt = 10
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = MSFNTrackingStation
+                    objectName = MSFN - Grand Canary
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 27.76282778
+                    lon = -15.63207778
+                    alt = 160
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = MSFNTrackingStation
+                    objectName = MSFN - Kano
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 11.999867
+                    lon = 8.537112
+                    alt = 500
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = MGSTrackingStation
+                    objectName = MGS - McMurdo
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -77.8386694
+                    lon = 166.6625901
+                    alt = 50
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = KSATTrackingStation
+                    objectName = KSAT - Troll Station
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -72.0113947
+                    lon = 2.541923
+                    alt = 1270
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = KSATTrackingStation
+                    objectName = KSAT - Svalbard
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 78.229772
+                    lon = 15.407786
+                    alt = 500
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
+                City2
+                {
+                    name = ESTRACKTrackingStation
+                    objectName = DSA 3 - Malargüe
+                    isKSC = False
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = -35.7762392
+                    lon = -69.3990988
+                    alt = 1550
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 10.0, 10.0, 10.0
+                            delete = False
+                        }
+                    }
+                }
+
                 City2
                 {
                     name = GenericTrackingStation
@@ -1378,35 +1755,6 @@
                 City2
                 {
                     name = GenericTrackingStation
-                    objectName = MGS - MGS McMurdo
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = -77.8386694
-                    lon = 166.6625901
-                    alt = 50
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
                     objectName = MSFN - BDA Bermuda
                     isKSC = False
                     commnetStation = True
@@ -1414,93 +1762,6 @@
                     lat = 32.3549
                     lon = -64.6605
                     alt = 135
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
-                    objectName = MSFN - CAN Grand Canary
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = 28.0068
-                    lon = -15.5984
-                    alt = 300
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
-                    objectName = MSFN - GUY Guaymas Mexico
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = 27.911140
-                    lon = -110.913240
-                    alt = 300
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
-                    objectName = MSFN - HAW Kauai Hawaii
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = 22.060649
-                    lon = -159.532340
-                    alt = 5000
                     snapHeightOffset = 0
                     up = 0.0, 1.0, 0.0
                     rotation = 0
@@ -1552,35 +1813,6 @@
                 City2
                 {
                     name = GenericTrackingStation
-                    objectName = MSFN - KAN Kano Nigeria
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = 11.999867
-                    lon = 8.537112
-                    alt = 5000
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
                     objectName = MSFN - POS Pacific Ocean
                     isKSC = False
                     commnetStation = True
@@ -1588,35 +1820,6 @@
                     lat = 0.0
                     lon = 177.0
                     alt = 0.0
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
-                    objectName = SG3 - KSAT Svalbard
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = 69.6617869
-                    lon = 18.940005
-                    alt = 500
                     snapHeightOffset = 0
                     up = 0.0, 1.0, 0.0
                     rotation = 0
@@ -1675,35 +1878,6 @@
                     lat = 13.5876921
                     lon = 144.8386329
                     alt = 45
-                    snapHeightOffset = 0
-                    up = 0.0, 1.0, 0.0
-                    rotation = 0
-                    order = 100
-                    enabled = True
-
-                    LOD
-                    {
-                        Value
-                        {
-                            visibleRange = 30000
-                            keepActive = False
-                            model = BUILTIN/Dish
-                            scale = 10.0, 10.0, 10.0
-                            delete = False
-                        }
-                    }
-                }
-
-                City2
-                {
-                    name = GenericTrackingStation
-                    objectName = TR3 - KSAT Troll Station
-                    isKSC = False
-                    commnetStation = True
-                    snapToSurface = True
-                    lat = -72.0113947
-                    lon = 2.541923
-                    alt = 1300
                     snapHeightOffset = 0
                     up = 0.0, 1.0, 0.0
                     rotation = 0

--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -679,7 +679,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = STDNTrackingStation
                     objectName = STDN - Quito
@@ -708,7 +708,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = STDNTrackingStation
                     objectName = STDN - Ascension
@@ -737,7 +737,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = STDNTrackingStation
                     objectName = STDN - Johannesburg
@@ -766,7 +766,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = STDNTrackingStation
                     objectName = STDN - Tananarive
@@ -795,7 +795,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = STDNTrackingStation
                     objectName = STDN - Carnarvon
@@ -824,7 +824,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = MSFNTrackingStation
                     objectName = MSFN - Kauai
@@ -853,7 +853,7 @@
                     }
                 }
 
-				City2
+                City2
                 {
                     name = MSFNTrackingStation
                     objectName = MSFN - Guaymas


### PR DESCRIPTION
A selected number of additional tracking stations for RealAntennas (which disables GenericTrackingStation).
Where there is overlap with existing stations, they have been removed (to avoid duplication for RT users).

Primarily located in the Southern hemisphere as tracking is currently poor.

MSFN and STDN site data from https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19720012595.pdf with the exception of Kano station which uses existing data.

MGS McMurdo and the two KSAT stations from existing data. Note, Svalbard had incorrect coordinates, these have been corrected (the old coordinates refer to the KSAT HQ in Tromsø not the Svalbard site).