### PR TITLE
Fix Earth's heightmap and remove artificial noise

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -364,7 +364,7 @@
 				}
 				VertexHeightNoiseVertHeightCurve2
 				{
-					deformity = 7000
+					deformity = 0
 					ridgedAddSeed = 1384047773
 					ridgedAddFrequency = 64
 					ridgedAddLacunarity = 4
@@ -389,7 +389,7 @@
 				}
 				VertexRidgedAltitudeCurve
 				{
-					deformity = 1650
+					deformity = 0
 					ridgedAddSeed = 1384047773
 					ridgedAddFrequency = 140
 					ridgedAddLacunarity = 2.5
@@ -417,8 +417,8 @@
 				}
 				VertexHeightMap
 				{
-					offset = -2150.0 //-2000.0
-					deformity = 17300.0 //15600.0 //7000 // 5000
+					offset = -1147
+					deformity = 9350
 					map = RSS-Textures/PluginData/EarthHeight.dds
 				}
 				AltitudeAlpha


### PR DESCRIPTION
Set the deformity to 9350 and the offset to -1147. Those values correctly set
the altitude of Bonneville, Salar Uyuni, and Etosha Pan. Those locations were
chosen because they have very different altitudes and they are flat. The
flatness guarantees that there are no aliasing problems with the heightmap.

Because the deformity was reduced, the noise needed to be zeroed to prevent
random parts of Florida from being underwater and random islands popping up.

Fixes KSP-RO/RealSolarSystem#149