### PR TITLE
Fix PQS deactivate altitude for bodies

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -343,7 +343,7 @@
 
 		PQS
 		{
-			deactivateAltitude = 167000
+			deactivateAltitude = 140000
 			fadeStart = 102000
 			fadeEnd = 127000
 			Material

--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -345,7 +345,7 @@
 		{
 			deactivateAltitude = 140000
 			fadeStart = 102000
-			fadeEnd = 127000
+			fadeEnd = 122500
 			Material
 			{
 				saturation = 0.8

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
@@ -273,9 +273,9 @@
 			maxQuadLengthsPerFrame = 0.001
 			minLevel = 3
 			maxLevel = 12
-			deactivateAltitude = 167000
+			deactivateAltitude = 125000
 			fadeStart = 102000
-			fadeEnd = 127000
+			fadeEnd = 123000
 
 			materialType = AtmosphericOptimized
 			Material

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
@@ -274,8 +274,8 @@
 			minLevel = 3
 			maxLevel = 12
 			deactivateAltitude = 125000
-			fadeStart = 102000
-			fadeEnd = 123000
+			fadeStart = 89375
+			fadeEnd = 109375
 
 			materialType = AtmosphericOptimized
 			Material

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
@@ -98,9 +98,9 @@
 			minLevel = 2
 			maxLevel = 12
 			minDetailDistance = 8
-			deactivateAltitude = 87000
-			fadeStart = 52000
-			fadeEnd = 67000
+			deactivateAltitude = 110000
+			fadeStart = 72000
+			fadeEnd = 97000
 			Mods
 			{
 				VertexColorMap

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
@@ -198,9 +198,9 @@
 			minLevel = 2
 			maxLevel = 14
 			minDetailDistance = 8
-			deactivateAltitude = 87000
-			fadeStart = 52000
-			fadeEnd = 67000
+			deactivateAltitude = 110000
+			fadeStart = 72000
+			fadeEnd = 97000
 
 			Material
 			{

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Titan.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Titan.cfg
@@ -281,9 +281,9 @@
 
 		PQS
 		{
-			deactivateAltitude = 87000
-			fadeStart = 52000
-			fadeEnd = 67000
+			deactivateAltitude = 600000
+			fadeStart = 467000
+			fadeEnd = 525000
 			Mods
 			{
 				// Height

--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -268,9 +268,9 @@
 		}
 		PQS
 		{
-			deactivateAltitude = 111000
-			fadeStart = 76000
-			fadeEnd = 91000
+			deactivateAltitude = 145000
+			fadeStart = 101000
+			fadeEnd = 126875
 
 			Material
 			{


### PR DESCRIPTION
-This was obviously a placeholder value that was set to 167000 on all
bodies at one point. Since then it has been fixed on some bodies but
on Earth and Mars for instance, this remains above the atmosphere height which causes
the game to hang in orbit when you pass this altitude.

This has been fixed to bring it in line with all other bodies with an
atmosphere where it should deactivate below the atmo altitude

EDIT: Changed bodies fade in and out to match the RSSVE values