### PR TITLE
Fix SCANsat MM patches

### DIFF
--- a/GameData/RealSolarSystem/Compatibility/SCANsat.cfg
+++ b/GameData/RealSolarSystem/Compatibility/SCANsat.cfg
@@ -68,6 +68,68 @@
 		@best_alt *= 10
 	}
 }
+//	============================================================================
+//	Generic catchall for any parts that might contain a scansat module
+//	----------------------------------------------------------------------------
+@PART[*]:HAS[@MODULE[SCANsat]]:FOR[RealSolarSystem]
+{
+	@MODULE[SCANsat]:HAS[#sensorType[1]] //RADAR
+	{
+		@min_alt = 10000
+		@max_alt = 500000
+		@best_alt = 10000
+	}
+	
+	@MODULE[SCANsat]:HAS[#sensorType[2]] //SAR
+	{
+		@min_alt = 10000
+		@max_alt = 8000000
+		@best_alt = 7500000
+		
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.1
+		}
+	}
+	
+	@MODULE[SCANsat]:HAS[#sensorType[24]] //Biome
+	{
+		@min_alt = 10000
+		@max_alt = 5000000
+		@best_alt = 2500000
+		
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.2
+		}
+	}
+	
+	@MODULE[SCANsat]:HAS[#sensorType[32]] //BTDT
+	{
+		@min_alt = 0
+		@max_alt = 5000
+		@best_alt = 0
+		
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.001
+		}
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleSCANresourceScanner]]:FOR[RealSolarSystem]
+{
+	@MODULE[ModuleSCANresourceScanner]
+	{
+		@min_alt *= 2
+		@max_alt *= 10
+		@best_alt *= 10
+		
+		@RESOURCE[ElectricCharge]
+		{
+			@rate /= 2
+		}
+	}
+}
 
 @COACH_COMMNET[CommNet]
 {

--- a/GameData/RealSolarSystem/Compatibility/SCANsat.cfg
+++ b/GameData/RealSolarSystem/Compatibility/SCANsat.cfg
@@ -1,161 +1,85 @@
-// jrandom
-// ============================================================================
-// SCANSat range scaling for Real Solar System
-// ----------------------------------------------------------------------------
+//	jrandom
+//	============================================================================
+//	SCANSat range scaling for Real Solar System
+//	----------------------------------------------------------------------------
 
 
 
-// ============================================================================
-// SCANSat
-// ---------------------------------------------------------------------------- SCANsat_Scanner
-@PART[SCANsat_Scanner]
+//	============================================================================
+//	SCANSat
+//	---------------------------------------------------------------------------- SCANsat_Scanner
+@PART[SCANsat_Scanner]:FOR[RealSolarSystem]
 {
-    @description = The Scientific Committee on Advanced Navigation brings you this high performance RADAR altimetry sensor. Min Alt: 10km, Max Alt: 500km, Best Alt: 10km, FOV: 5
-    
-    @MODULE[SCANsat]
-    {
-        @min_alt = 10000
-        @max_alt = 500000
-        @best_alt = 10000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.05
-		}
-    }
+	@description = The Scientific Committee on Advanced Navigation brings you this high performance RADAR altimetry sensor. Min Alt: 10km, Max Alt: 500km, Best Alt: 10km, FOV: 5
+	
+	@MODULE[SCANsat]
+	{
+		@min_alt = 10000
+		@max_alt = 500000
+		@best_alt = 10000
+	}
 }
 
 // ---------------------------------------------------------------------------- SCANsat_Scanner2
-@PART[SCANsat_Scanner2]
+@PART[SCANsat_Scanner2]:FOR[RealSolarSystem]
 {
-    @description = This Synthetic Aperture RADAR sensor uses its flight path to simulate a much larger antenna. This makes it possible to detect terrain elevation at much higher resolution. The downside is that its field of view is comparatively small, and it works better at higher altitudes. Min Alt: 10km, Max Alt: 8000km, Best Alt: 7500km, FOV: 2
-    
-    @MODULE[SCANsat]
-    {
-        @min_alt = 10000
-        @max_alt = 8000000
-        @best_alt = 7500000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.1
-		}
-    }
+	@description = This Synthetic Aperture RADAR sensor uses its flight path to simulate a much larger antenna. This makes it possible to detect terrain elevation at much higher resolution. The downside is that its field of view is comparatively small, and it works better at higher altitudes. Min Alt: 10km, Max Alt: 8000km, Best Alt: 7500km, FOV: 2
+	
+	@MODULE[SCANsat]
+	{
+		@min_alt = 10000
+		@max_alt = 8000000
+		@best_alt = 7500000
+	}
 }
 
 // ---------------------------------------------------------------------------- SCANsat_Scanner24
-@PART[SCANsat_Scanner24]
+@PART[SCANsat_Scanner24]:FOR[RealSolarSystem]
 {
-    @description = This multichannel sensor detects radiation across several infrared, visible light, and RADAR bands. This gives it the capability to differentiate between terrain types and biomes. It can also detect anomalies such as structures on the ground. Min Alt: 10km, Max Alt: 5000km, Best Alt: 2500km, FOV: 4
-    
-    @MODULE[SCANsat]
-    {
-        @min_alt = 10000
-        @max_alt = 5000000
-        @best_alt = 2500000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.2
-		}
-    }
+	@description = This multichannel sensor detects radiation across several infrared, visible light, and RADAR bands. This gives it the capability to differentiate between terrain types and biomes. It can also detect anomalies such as structures on the ground. Min Alt: 10km, Max Alt: 5000km, Best Alt: 2500km, FOV: 4
+	
+	@MODULE[SCANsat]
+	{
+		@min_alt = 10000
+		@max_alt = 5000000
+		@best_alt = 2500000
+	}
 }
 
 // ---------------------------------------------------------------------------- SCANsat_Scanner32
-@PART[SCANsat_Scanner32]
+@PART[SCANsat_Scanner32]:FOR[RealSolarSystem]
 {
-    @description = This small sensor can automatically identify nearby anomalies. Since it only works over very short distances and at very low altitudes, it's primarily useful to track identified anomalies that have been visited. Min Alt: 0, Max Alt: 5km, Best Alt: 0, FOV: 1
-    
-    @MODULE[SCANsat]
-    {
-        @min_alt = 0
-        @max_alt = 5000
-        @best_alt = 0
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.001
-		}
-    }
-}
-
-@PART[*]:HAS[@MODULE[SCANsat]]:AFTER[SCANSat]
-{
-	@MODULE[SCANsat]:HAS[#sensorType[1]] //RADAR
-	{
-		@min_alt = 10000
-        @max_alt = 500000
-        @best_alt = 10000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.05
-		}
-	}
+	@description = This small sensor can automatically identify nearby anomalies. Since it only works over very short distances and at very low altitudes, it's primarily useful to track identified anomalies that have been visited. Min Alt: 0, Max Alt: 5km, Best Alt: 0, FOV: 1
 	
-	@MODULE[SCANsat]:HAS[#sensorType[2]] //SAR
-	{
-		@min_alt = 10000
-        @max_alt = 8000000
-        @best_alt = 7500000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.1
-		}
-	}
-	
-	@MODULE[SCANsat]:HAS[#sensorType[24]] //Biome
-	{
-		@min_alt = 10000
-        @max_alt = 5000000
-        @best_alt = 2500000
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.2
-		}
-	}
-	
-	@MODULE[SCANsat]:HAS[#sensorType[32]] //BTDT
+	@MODULE[SCANsat]
 	{
 		@min_alt = 0
-        @max_alt = 5000
-        @best_alt = 0
-        
-		@RESOURCE[ElectricCharge]
-		{
-			@rate = 0.001
-		}
+		@max_alt = 5000
+		@best_alt = 0
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleSCANresourceScanner]]:AFTER[SCANSat]
+@PART[*]:HAS[@MODULE[ModuleSCANresourceScanner]]:FOR[RealSolarSystem]
 {
 	@MODULE[ModuleSCANresourceScanner]
 	{
 		@min_alt *= 2
 		@max_alt *= 10
-        @best_alt *= 10
-		
-		@RESOURCE[ElectricCharge]
-		{
-			@rate /= 2
-		}
+		@best_alt *= 10
 	}
 }
 
 @COACH_COMMNET[CommNet]
 {
 	@MODULE[SCANsat]
-    {
-        @min_alt = 10000
-        @max_alt = 5000000
-        @best_alt = 2500000
-        
+	{
+		@min_alt = 10000
+		@max_alt = 5000000
+		@best_alt = 2500000
+		
 		@RESOURCE[ElectricCharge]
 		{
 			@rate = 0.2
 		}
-    }
+	}
 }


### PR DESCRIPTION
Clean up the RSS compatibility patches for SCANsat, including:

- Remove patches that modify power draw. That isn't within the purview of RSS, mods that modify the power system (such as RO) should change it themselves

- Change patches from running AFTER[SCANsat] to FOR[RealSolarSystem], so other mods (like RO) can actually modify the parts how they see fit without being forced to use FINAL.