### PR TITLE
Fix some vesta biome colors

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Vesta/Vesta.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Vesta/Vesta.cfg
@@ -100,14 +100,14 @@
 					name = Albana Crater
 					displayName = #RSS_Vesta_Biome9
 					value = 1.0
-					color = 0.6,1,1,1
+					color = 0.835,1,1,1
 				}
 				Biome
 				{
 					name = Pomponia Crater
 					displayName = #RSS_Vesta_Biome10
 					value = 1.0
-					color = 0.6,1,0,1
+					color = 0.82,1,0,1
 				}
 				Biome
 				{


### PR DESCRIPTION
Albana and Pomponia craters were registering as midlands, both because their red value was wrong (in the same way, weird)

Tested with RSS-Textures 18.3 16k _only_. Someone probably should check other resolutions, in case the problem is actually the 16k .dds not matching the others.