### PR TITLE
Add comets to Custom Asteroids config

### DIFF
--- a/GameData/RealSolarSystem/CometDefs.cfg
+++ b/GameData/RealSolarSystem/CometDefs.cfg
@@ -1,0 +1,23 @@
+// Comet classes specific to RSS
+
+COMET_ORBIT_TYPE
+{
+	name = centaur
+	// TODO: these strings should be localized, but I can't provide translations myself
+	displayName = Centaur
+	description = Centaurs are icy bodies that have been pulled into the outer solar system by the gravity of Neptune and the other giant planets. Some of them show cometary activity and many may eventually become short- or intermediate-period comets, but for now they orbit beyond Jupiter.
+	inclination1Min = -40
+	inclination1Max = 40
+	inclination2Min = 120
+	inclination2MAx = 180
+	inclination1Chance = 0.8
+	// pe, ap in units of FlightGlobals.GetCometPerturber()
+	// I assume this is Jupiter for RSS
+	peMin = 1.0
+	peMax = 3.5
+	apMin = 1.25		// In tests, KSP handles peMax > apMin just fine
+	apMax = 6.0
+	minCometClass = F
+	maxCometClass = H
+	chanceWeight = 5	// KSP 1.11 gives 50:40:9:1 for stock classes
+}

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -5,6 +5,12 @@
 // Prevent accidentally installed stock configs from interfering
 !AsteroidSets[CustomAsteroids_*]:FOR[RealSolarSystem] {}
 
+// Don't use both Custom Asteroids and Kopernicus for asteroids/comets
+@Kopernicus:AFTER[RealSolarSystem]:NEEDS[CustomAsteroids]
+{
+    !Asteroid,*{}
+}
+
 CustomAsteroidPlanes {
 	// From Souami & Souchay (2012), Astronomy & Astrophysics, 543, A133
 	// Converted to 1950 coordinates using HEASARC coordinate converter:

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -1,5 +1,5 @@
 // Real Solar System Custom Asteroids Configuration
-// For Custom Asteroids 1.3.1+
+// For Custom Asteroids 1.9.0+
 // Compatible with Real Solar System v10.1+
 
 // Prevent accidentally installed stock configs from interfering
@@ -212,8 +212,12 @@ AsteroidSets
 			key = 0.79 CaAsteroidCarbon
 			key = 0.10 CaAsteroidMetal
 			// Why not add some main belt comets?
-			key = 0.01 CaCometActive
+			key = 0.01 PotatoComet
 		}
+
+		// Support MBCs
+		orbitType = activeAsteroid
+		useCometName = false
 	}
 	
 	ASTEROIDGROUP
@@ -346,7 +350,16 @@ AsteroidSets
 
 		asteroidTypes
 		{
-			key = 1.0 CaCometActive
+			key = 1.0 PotatoComet
+		}
+
+		orbitType = long
+
+		// Stock size distribution
+		sizes
+		{
+			key = 0.5 G
+			key = 0.5 H
 		}
 	}
 	
@@ -500,16 +513,25 @@ AsteroidSets
 
 		asteroidTypes
 		{
-			key = 0.10 CaAsteroidCarbon
-			key = 0.70 CaAsteroidIcy
-			key = 0.20 CaCometActive
+			key = 1.0 PotatoComet
+		}
+
+		orbitType = centaur
+		useCometName = false		// Use minor planet names
+
+		// Same size distribution as intermediate-period comets
+		sizes
+		{
+			key = 0.3 F
+			key = 0.4 G
+			key = 0.3 H
 		}
 	}
 
 	ASTEROIDGROUP
 	{
 		name = midComets
-		title = Periodic Cmt.
+		title = Damocloid		// Used only if *not* a comet
 
 		centralBody = Sun
 
@@ -538,14 +560,26 @@ AsteroidSets
 		asteroidTypes
 		{
 			key = 0.20 CaAsteroidCarbon
-			key = 0.80 CaCometActive
+			key = 0.80 PotatoComet
+		}
+
+		orbitType = intermediate
+
+		// Stock size distribution
+		sizes
+		{
+			key = 0.3 F
+			key = 0.4 G
+			key = 0.3 H
 		}
 	}
 
 	ASTEROIDGROUP
 	{
 		name = jupiterComets
-		title = Jupiter-Family Cmt.
+		// Title used only if not a comet
+		// Dormant/extinct JFCs indistinguishable from other NEOs
+		title = Near-Earth Ast.
 
 		centralBody = Sun
 
@@ -574,7 +608,70 @@ AsteroidSets
 		asteroidTypes
 		{
 			key = 0.25 CaAsteroidCarbon
-			key = 0.75 CaCometActive
+			key = 0.75 PotatoComet
+		}
+
+		orbitType = short
+
+		// Stock size distribution
+		sizes
+		{
+			key = 0.5 E
+			key = 0.5 F
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = interstellarComets
+		title = #autoLOC_8003390
+
+		asteroidTypes
+		{
+			key = 1 PotatoComet
+		}
+
+		orbitType = interstellar
+
+		centralBody = Sun
+
+		spawnRate = 0.004
+
+		orbitSize
+		{
+			type = Periapsis
+			dist = Uniform
+			min = Ratio(Earth.sma, 0.5)
+			max = Ratio(Jupiter.sma, 0.5)
+		}
+
+		eccentricity
+		{
+			dist = Uniform
+			min = 1.1		// Excess velocity 6-13 km/s
+			max = 4			// Excess velocity 30-70 km/s
+		}
+
+		inclination
+		{
+			dist = Isotropic
+		}
+
+		sizes
+		{
+			key = 0.5 G
+			key = 0.5 I
+		}
+
+		orbitPhase
+		{
+			// Let comets be discovered only on approach, so that the player has
+			// time to prepare a flyby mission
+			dist = Uniform
+			type  = MeanAnomaly
+			epoch = Now
+			min = -4
+			max = -2
 		}
 	}
 }

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -321,15 +321,14 @@ AsteroidSets
 		orbitSize
 		{
 			type = Periapsis
-			//min =   261600000	// Sungrazers
-			min = Ratio(Mercury.sma, 0.2)
-			max = Ratio(Jupiter.sma, 1.0)	// Ignore comets outside the orbit of Jupiter
+			min = Ratio(Mercury.sma, 1.0)
+			max = Ratio(Jupiter.sma, 0.5)
 		}
 
 		eccentricity
 		{
 			dist = Uniform
-			min = 0.98		// Minimum apoapsis: 1.7× Jupiter's orbit
+			min = 0.98		// Minimum period ~ 85 years
 			max = 1.005
 		}
 
@@ -548,7 +547,7 @@ AsteroidSets
 		eccentricity
 		{
 			dist = Uniform
-			min  = 0.7		// W/ apoapsis constraint, gives periapsis inside Jupiter
+			min  = 0.8		// W/ apoapsis constraint, gives periapsis inside Jupiter
 			max  = 0.99999
 		}
 
@@ -576,9 +575,10 @@ AsteroidSets
 
 	ASTEROIDGROUP
 	{
+		// Now covers Encke-type comets as well, but keep name for backward-compatibility
 		name = jupiterComets
 		// Title used only if not a comet
-		// Dormant/extinct JFCs indistinguishable from other NEOs
+		// Dormant/extinct short-period indistinguishable from other NEOs
 		title = Near-Earth Ast.
 
 		centralBody = Sun
@@ -589,15 +589,15 @@ AsteroidSets
 		orbitSize
 		{
 			type = SemimajorAxis
-			min  = Ratio(Jupiter.sma, 0.7)		// T_J <~ 3
+			min  = Ratio(Jupiter.sma, 0.5)		// Period > 4 years
 			max  = Ratio(Jupiter.sma, 1.4)		// Period of < 20 years
 		}
 
 		eccentricity
 		{
 			dist = Gaussian
-			avg    = 0.5
-			stddev = 0.18
+			avg    = 0.6
+			stddev = 0.14
 		}
 
 		inclination

--- a/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
+++ b/GameData/RealSolarSystem/Compatibility/CustomAsteroids.cfg
@@ -308,6 +308,9 @@ AsteroidSets
 		}
 	}
 
+	// Want total spawn rate of ~0.01 for comets, as naming algorithm
+	// seems to be designed for ~4 comets per year.
+
 	ASTEROIDGROUP
 	{
 		name = oort
@@ -315,8 +318,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// One comet every 40 Earth days
-		spawnRate = 0.025
+		spawnRate = 0.001
 
 		orbitSize
 		{
@@ -490,8 +492,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 0.3 centaurs will be around on average
-		spawnRate = 0.025
+		spawnRate = 0.002
 
 		orbitSize
 		{
@@ -534,8 +535,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 1.1 comets will be around on average
-		spawnRate = 0.05
+		spawnRate = 0.004
 
 		orbitSize
 		{
@@ -583,8 +583,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		// With default lifetime settings, 1.1 comets will be around on average
-		spawnRate = 0.05
+		spawnRate = 0.004
 
 		orbitSize
 		{
@@ -635,7 +634,7 @@ AsteroidSets
 
 		centralBody = Sun
 
-		spawnRate = 0.004
+		spawnRate = 0.0002
 
 		orbitSize
 		{

--- a/GameData/RealSolarSystem/ScienceDefs.cfg
+++ b/GameData/RealSolarSystem/ScienceDefs.cfg
@@ -700,3 +700,23 @@ Because a fire engine has four wheels and eight men. Four and eight are twelve. 
 		CharonInSpace = #RSS_Science_MML_CharonInSpace//You let the computer process the results. For now, you need another nap.
 	}
 }
+
+EXPERIMENT_DEFINITION
+{
+	id = cometSample_centaur
+	// TODO: title and results should be localized, but I can't provide translations myself
+	title = Centaur Sample
+	baseValue = 180
+	scienceCap = 200	// vs. intermediate- (150) and long-period comets (300)
+	dataScale = 1
+
+	requireAtmosphere = False
+	requireNoAtmosphere = False
+	situationMask = 63
+	biomeMask = 7
+
+	RESULTS
+	{
+		default = This Centaur has remained relatively untouched since its ejection from trans-Neptunian space, and will help our scientists get a better look at conditions in the outermost regions of the protoplanetary disk. It's certainly easier than going all the way out to the Kuiper belt.
+	}
+}


### PR DESCRIPTION
This PR replaces `CaCometActive` in the Custom Asteroids config with `PotatoComet`, along with comet-related features that will be introduced in Custom Asteroids 1.9. It includes some unlocalized science and name text, as I'm not able to provide the Chinese localization myself. Sorry about that.

This PR will break RealSolarSystem compatibility with KSP 1.9 or earlier, and it may be best to hold off merging until RSS decides how it wants to handle comets using the default Kopernicus system. ~In the absence of an RSS build for 1.10, I have not been able to test these changes yet.~ Tested on KSP 1.11 with RSS 18.1.3 and Kopernicus R-T-B 61.

Closes #207.