### PR TITLE
Adjust PQS transition for Earth to reduce artifacts

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -355,8 +355,8 @@
 		PQS
 		{
 			deactivateAltitude = 140000
-			fadeStart = 102000
-			fadeEnd = 122500
+			fadeStart = 135000
+			fadeEnd = 140000
 			
 			materialType = AtmosphericTriplanarZoomRotation
 			Material


### PR DESCRIPTION
* with newer scatterer / RSSVE combinations these values give very little artifacting around the 140 transition as opposed to the gigantic tiling currently going on because the "dead zone" after the PQS end does not play nicely with scatterer.