### PR TITLE
Configure albedo and emissivity for planets

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -42,6 +42,8 @@
 			tidallyLocked = false
 			// does nothing - axialTilt = 23.44
 			gravParameter = 3.986004418e+14
+			albedo = 0.29
+			emissivity = 0.71
 			timewarpAltitudeLimits = 0 140000 140000 140000 140000 2000000 35000000 35000000
 
 			// Set navball switching around the Karman line

--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -38,6 +38,8 @@
 			tidallyLocked = true
 			initialRotation = 25
 			isHomeWorld = false
+			albedo = 0.123
+			emissivity = 0.877
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/MoonBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Jupiter.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Jupiter.cfg
@@ -37,7 +37,8 @@
 			tidallyLocked = false
 			initialRotation = 25
 			isHomeWorld = false
-			emissivity = 0.00065
+			albedo = 0.343
+			emissivity = 0.657
 			// timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000 // No idea how to get them
 
 			biomeMap = RSS-Textures/PluginData/JupiterBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
@@ -38,6 +38,8 @@
 			tidallyLocked = false
 			initialRotation = 25
 			isHomeWorld = false
+			albedo = 0.16
+			emissivity = 0.84
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/MarsBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
@@ -39,6 +39,8 @@
 			tidallyLocked = false
 			initialRotation = 0
 			isHomeWorld = false
+			albedo = 0.119
+			emissivity = 0.881
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/MercuryBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Neptune.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Neptune.cfg
@@ -38,7 +38,8 @@
 			tidallyLocked = false
 			initialRotation = 0
 			isHomeWorld = false
-			emissivity = 0.00065
+			albedo = 0.31
+			emissivity = 0.69
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 			
 			biomeMap = RSS-Textures/PluginData/NeptuneBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
@@ -38,6 +38,8 @@
 			tidallyLocked = false
 			initialRotation = 0
 			isHomeWorld = false
+			albedo = 0.4
+			emissivity = 0.6
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/PlutoBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Saturn.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Saturn.cfg
@@ -38,7 +38,8 @@
 			tidallyLocked = false
 			initialRotation = 0
 			isHomeWorld = false
-			emissivity = 0.00065
+			albedo = 0.342
+			emissivity = 0.658
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/SaturnBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Uranus/Uranus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Uranus/Uranus.cfg
@@ -38,7 +38,8 @@
 			tidallyLocked = false
 			initialRotation = 0
 			isHomeWorld = false
-			emissivity = 0.00065
+			albedo = 0.29
+			emissivity = 0.71
 			timewarpAltitudeLimits = 0 5000 30000 30000 100000 300000 600000 1000000
 
 			biomeMap = RSS-Textures/PluginData/UranusBiomes.dds

--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -42,8 +42,8 @@
 			// does nothing - axialTilt = 23.44
 			gravParameter = 3.24859e+14
 			isHomeWorld = false
-			emissivity = 0.00065
-
+			albedo = 0.75
+			emissivity = 0.25
 			timewarpAltitudeLimits = 0 145000 145000 145000 1000000 10000000 25000000 35000000
 
 			biomeMap = RSS-Textures/PluginData/VenusBiomes.dds


### PR DESCRIPTION
Set body values for albedo and emissivity, instead of relying on the KSP templates these bodies are based on. This ends up very wrong for most cases other than Earth, the Moon, and Mars.

Note KSP (and Kopernicus supports) independently treats emissivity and albedo, which is wrong for planetary bodies: they have a fixed relationship of emissivity + albedo = 1. So set both.

From Got in Kerbalism Discord:
>There is a table in the wiki page I linked that gives values for a bunch of solar system bodies. I remember trying to double check with multiple sources, so they should be accurate. This being said, I didn't save all the sources, but I got some data from "de Pater, Imke and Lissauer, Jack, Planetary Sciences, Cambridge University Press, 2001." 
![image](https://user-images.githubusercontent.com/25906300/162794966-91e15ab2-4062-41ed-9a3f-4b0e9391e4ec.png)
