### PR TITLE
Add missing launch site tracking stations

### DIFF
--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -388,6 +388,64 @@
                         }
                     }
                 }
+                
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = KP - Sohae
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 39.66
+                    lon = 124.705
+                    alt = 85
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 0.1, 0.1, 0.1
+                            delete = False
+                        }
+                    }
+                }
+                
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = KR - Naro
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 34.431867
+                    lon = 127.535069
+                    alt = 0
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 0.1, 0.1, 0.1
+                            delete = False
+                        }
+                    }
+                }
 
                 City2
                 {
@@ -776,7 +834,7 @@
                     snapToSurface = True
                     lat = 32.943242
                     lon = -106.419531
-                    alt = 1245.68
+                    alt = 1195
                     snapHeightOffset = 0
                     up = 0.0, 1.0, 0.0
                     rotation = 0

--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -766,6 +766,35 @@
                         }
                     }
                 }
+                
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = US - White Sands
+                    isKSC = True
+                    commnetStation = True
+                    snapToSurface = True
+                    lat = 32.943242
+                    lon = -106.419531
+                    alt = 1245.68
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                    enabled = True
+
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 0.1, 0.1, 0.1
+                            delete = False
+                        }
+                    }
+                }
 
                 City2
                 {


### PR DESCRIPTION
White Sands and the Korean launch sites are not currently usable without Comms. Adding it here.