### PR TITLE
Add actual terrain quality presets

### DIFF
--- a/GameData/RealSolarSystem/Compatibility/Parallax/Parallax.cfg
+++ b/GameData/RealSolarSystem/Compatibility/Parallax/Parallax.cfg
@@ -830,7 +830,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 12
 			%Mods
 			{
 				Subdivide
@@ -848,7 +847,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 12
 			%Mods
 			{
 				Subdivide
@@ -862,19 +860,10 @@
 			}
 		}
 	}
-    @Body[Kerbin]
-	{
-		%PQS
-		{
-			// Leaving this but not adding the Subdivision PQSMod
-			%maxLevel = 12
-		}
-	}
 	@Body[Moon]
 	{
 		%PQS
 		{
-			%maxLevel = 11
 			%Mods
 			{
 				Subdivide
@@ -892,7 +881,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 12
 			%Mods
 			{
 				Subdivide
@@ -910,7 +898,6 @@
 	{
 		%PQS
 		{
-			//%maxLevel = 3
 			%Mods
 			{
 				Subdivide
@@ -973,7 +960,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 11
 			%Mods
 			{
 				Subdivide
@@ -989,7 +975,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 11
 			%Mods
 			{
 				Subdivide
@@ -1005,7 +990,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 12
 			%Mods
 			{
 				Subdivide
@@ -1021,7 +1005,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 12
 			%Mods
 			{
 				Subdivide
@@ -1037,7 +1020,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1053,7 +1035,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1069,7 +1050,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1085,7 +1065,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1101,7 +1080,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1117,7 +1095,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 11
 			%Mods
 			{
 				Subdivide
@@ -1133,7 +1110,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide
@@ -1149,7 +1125,6 @@
 	{
 		%PQS
 		{
-			%maxLevel = 10
 			%Mods
 			{
 				Subdivide

--- a/GameData/RealSolarSystem/RSS_TerrainDetailPresets.cfg
+++ b/GameData/RealSolarSystem/RSS_TerrainDetailPresets.cfg
@@ -2,232 +2,729 @@
 {
 	Preset
 	{
-		name = RSS_High
-		displayName = RSS High Res
+		name = Low
 		PLANET
 		{
-			name = Kerbin
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 10
-		}
-		PLANET
-		{
-			name = Moon
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 10
-		}
-		PLANET
-		{
-			name = Mercury
-			minDistance = 8
+			name = Kerbin	// R 6371 km
+			minDistance = 6
 			minSubdivision = 1
 			maxSubdivision = 9
 		}
 		PLANET
 		{
-			name = Venus
+			name = KerbinOcean
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Moon	// R 1737 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Mercury	// R 2439 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Venus	// R 6052 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Mars	// R 3389 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Phobos	// R 11.1 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 5
+		}
+		PLANET
+		{
+			name = Deimos	// R 6.2 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 5
+		}
+		PLANET
+		{
+			name = Vesta	// R 263 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Ceres	// R 470 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Jupiter	// R 69911 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Callisto	// R 2410 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Europa	// R 1561 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Ganymede	// R 2634 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Io	// R 1822 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Saturn	// R 58232 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Dione	// R 562 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Enceladus	// R 252 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Iapetus	// R 736 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Mimas	// R 198 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Rhea	// R 763 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Tethys	// R 533 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Titan	// R 2575 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = TitanOcean
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 5
+		}
+		PLANET
+		{
+			name = Uranus	// R 25362 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Ariel	// R 579 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Miranda	// R 236 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Oberon	// R 761 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Titania	// R 789 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Umbriel	// R 585 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Neptune	// R 24622 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Triton	// R 1354 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Pluto	// R 1188 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Charon	// R 606 km
+			minDistance = 6
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+	}
+	Preset
+	{
+		name = Default
+		PLANET
+		{
+			name = Kerbin	// R 6371 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = KerbinOcean
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Moon	// R 1737 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Mercury	// R 2439 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Venus	// R 6052 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Mars	// R 3389 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Phobos	// R 11.1 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 5
+		}
+		PLANET
+		{
+			name = Deimos	// R 6.2 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 5
+		}
+		PLANET
+		{
+			name = Vesta	// R 263 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Ceres	// R 470 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Jupiter	// R 69911 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Callisto	// R 2410 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Europa	// R 1561 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Ganymede	// R 2634 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Io	// R 1822 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Saturn	// R 58232 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Dione	// R 562 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Enceladus	// R 252 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Iapetus	// R 736 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Mimas	// R 198 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Rhea	// R 763 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Tethys	// R 533 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Titan	// R 2575 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = TitanOcean
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Uranus	// R 25362 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Ariel	// R 579 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Miranda	// R 236 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Oberon	// R 761 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Titania	// R 789 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Umbriel	// R 585 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Neptune	// R 24622 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Triton	// R 1354 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Pluto	// R 1188 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Charon	// R 606 km
+			minDistance = 7
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+	}
+
+	Preset
+	{
+		name = High
+		PLANET
+		{
+			name = Kerbin	// R 6371 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 11
+		}
+		PLANET
+		{
+			name = KerbinOcean
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Moon	// R 1737 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Mars
+			name = Mercury	// R 2439 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Phobos
+			name = Venus	// R 6052 km
 			minDistance = 8
 			minSubdivision = 1
-			maxSubdivision = 6	
+			maxSubdivision = 11
 		}
 		PLANET
 		{
-			name = Deimos
+			name = Mars	// R 3389 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Phobos	// R 11.1 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 6
 		}
 		PLANET
 		{
-			name = Vesta
+			name = Deimos	// R 6.2 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 6
+		}
+		PLANET
+		{
+			name = Vesta	// R 263 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 8
 		}
 		PLANET
 		{
-			name = Ceres
+			name = Ceres	// R 470 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 8
 		}
 		PLANET
 		{
-			name = Jupiter
+			name = Jupiter	// R 69911 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Callisto
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Europa
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Ganymede
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Io
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Saturn
+			name = Callisto	// R 2410 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Dione
+			name = Europa	// R 1561 km
 			minDistance = 8
 			minSubdivision = 1
-			maxSubdivision = 7
+			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Enceladus
+			name = Ganymede	// R 2634 km
 			minDistance = 8
 			minSubdivision = 1
-			maxSubdivision = 7
+			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Iapetus
+			name = Io	// R 1822 km
 			minDistance = 8
 			minSubdivision = 1
-			maxSubdivision = 7
+			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Mimas
+			name = Saturn	// R 58232 km
 			minDistance = 8
 			minSubdivision = 1
-			maxSubdivision = 7
+			maxSubdivision = 10
 		}
 		PLANET
 		{
-			name = Rhea
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Tethys
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Titan
+			name = Dione	// R 562 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 9
 		}
 		PLANET
 		{
-			name = Uranus
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 10
-		}
-		PLANET
-		{
-			name = Ariel
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Miranda
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Oberon
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Titania
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Umbriel
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 7
-		}
-		PLANET
-		{
-			name = Neptune
-			minDistance = 8
-			minSubdivision = 1
-			maxSubdivision = 10
-		}
-		PLANET
-		{
-			name = Triton
+			name = Enceladus	// R 252 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 8
 		}
 		PLANET
 		{
-			name = Pluto
+			name = Iapetus	// R 736 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Mimas	// R 198 km
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 8
 		}
 		PLANET
 		{
-			name = Charon
+			name = Rhea	// R 763 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Tethys	// R 533 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Titan	// R 2575 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = TitanOcean
 			minDistance = 8
 			minSubdivision = 1
 			maxSubdivision = 7
+		}
+		PLANET
+		{
+			name = Uranus	// R 25362 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Ariel	// R 579 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Miranda	// R 236 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 8
+		}
+		PLANET
+		{
+			name = Oberon	// R 761 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Titania	// R 789 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Umbriel	// R 585 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
+		}
+		PLANET
+		{
+			name = Neptune	// R 24622 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Triton	// R 1354 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Pluto	// R 1188 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 10
+		}
+		PLANET
+		{
+			name = Charon	// R 606 km
+			minDistance = 8
+			minSubdivision = 1
+			maxSubdivision = 9
 		}
 	}
 }
-		

--- a/Source/InstallationChecker.cs
+++ b/Source/InstallationChecker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace RealSolarSystem
@@ -7,70 +8,119 @@ namespace RealSolarSystem
     [KSPAddon(KSPAddon.Startup.Instantly, true)]
     class RSSInstallationCheck : MonoBehaviour
     {
-        public void Start ()
+        public void Start()
         {
             try
             {
-                string szTextureFolderPath = $"{KSPUtil.ApplicationRootPath}GameData{Path.AltDirectorySeparatorChar}RSS-Textures";
-
-                const string szUserMessage = "The texture pack for RealSolarSystem is missing from your installation\n\nDownload it from the official GitHub KSP-RO repository.";
-
-                if (!Directory.Exists (szTextureFolderPath))
-                {
-                    Debug.Log ("[RealSolarSystem] No texture pack detected!");
-
-                    PopupDialog.SpawnPopupDialog
-                    (
-                        new Vector2 (0.0f, 0.0f),
-                        new Vector2 (0.0f, 0.0f),
-                        new MultiOptionDialog
-                        (
-                            "RSSInstallCheck",
-                            szUserMessage,
-                            "Missing RSS Texture Pack",
-                            HighLogic.UISkin,
-                            new Rect (0.25f, 0.75f, 320f, 80f),
-                            new DialogGUIFlexibleSpace (),
-                            new DialogGUIButton
-                            (
-                                "Download",
-                                delegate
-                                {
-                                    OnOpenPage ();
-                                },
-                                140.0f,
-                                30.0f,
-                                true
-                            )
-                        ),
-                        false,
-                        HighLogic.UISkin,
-                        true,
-                        string.Empty
-                    );
-                }
-                else
-                {
-                    var fi = new FileInfo(Path.Combine(szTextureFolderPath, "EarthColor.dds"));
-                    if (fi.Exists)
-                    {
-                        Debug.Log($"[RealSolarSystem] EarthColor.dds size: {(fi.Length / 1024d / 1024d):F1}MB");
-                    }
-                }
+                CheckTexturesInstalled();
+                CheckCompatibleKopInstalled();
             }
-            catch (Exception exceptionStack)
+            catch (Exception ex)
             {
-                Debug.Log("[RealSolarSystem] RSSInstallationCheck.Start() caught an exception: " + exceptionStack);
+                Debug.Log("[RealSolarSystem] RSSInstallationCheck.Start() caught an exception: " + ex);
             }
             finally
             {
-                Destroy (this);
+                Destroy(this);
             }
         }
 
-        void OnOpenPage ()
+        private void CheckTexturesInstalled()
         {
-            Application.OpenURL ("https://github.com/KSP-RO/RSS-Textures/releases/latest");
+            string szTextureFolderPath = $"{KSPUtil.ApplicationRootPath}GameData{Path.AltDirectorySeparatorChar}RSS-Textures";
+
+            const string szUserMessage = "The texture pack for RealSolarSystem is missing from your installation\n\nDownload it from the official GitHub KSP-RO repository.";
+
+            if (!Directory.Exists(szTextureFolderPath))
+            {
+                Debug.Log("[RealSolarSystem] No texture pack detected!");
+
+                PopupDialog.SpawnPopupDialog
+                (
+                    new Vector2(0.0f, 0.0f),
+                    new Vector2(0.0f, 0.0f),
+                    new MultiOptionDialog
+                    (
+                        "RSSInstallCheck",
+                        szUserMessage,
+                        "Missing RSS Texture Pack",
+                        HighLogic.UISkin,
+                        new Rect(0.25f, 0.75f, 320f, 80f),
+                        new DialogGUIFlexibleSpace(),
+                        new DialogGUIButton
+                        (
+                            "Download",
+                            delegate
+                            {
+                                OpenRSSTexturesDownloadPage();
+                            },
+                            140.0f,
+                            30.0f,
+                            true
+                        )
+                    ),
+                    false,
+                    HighLogic.UISkin,
+                    true,
+                    string.Empty
+                );
+            }
+            else
+            {
+                var fi = new FileInfo(Path.Combine(szTextureFolderPath, "EarthColor.dds"));
+                if (fi.Exists)
+                {
+                    Debug.Log($"[RealSolarSystem] EarthColor.dds size: {(fi.Length / 1024d / 1024d):F1}MB");
+                }
+            }
+        }
+
+        private void CheckCompatibleKopInstalled()
+        {
+            string kopVer = Kopernicus.Constants.Version.VersionNumber;    // Is in format "Release-160"
+            string sRelNum = kopVer.Split('-').Last();
+            bool success = int.TryParse(sRelNum, out int relNum);
+
+            const int minKopReleaseVer = 161;
+
+            if (!success || relNum < minKopReleaseVer)
+            {
+                Debug.Log("[RealSolarSystem] Invalid Kopernicus version detected: " + kopVer);
+
+                string errorMsg = $"The currently installed version of Kopernicus ({kopVer}) is missing features required for RSS to function properly.\n\nPlease install Kopernicus release {minKopReleaseVer} or newer.";
+
+                PopupDialog.SpawnPopupDialog
+                (
+                    new Vector2(0.0f, 0.0f),
+                    new Vector2(0.0f, 0.0f),
+                    new MultiOptionDialog
+                    (
+                        "RSSKopInstallCheck",
+                        errorMsg,
+                        "Incompatible Kopernicus version found",
+                        HighLogic.UISkin,
+                        new Rect(0.35f, 0.65f, 320f, 80f),
+                        new DialogGUIFlexibleSpace(),
+                        new DialogGUIButton
+                        (
+                            "Understood",
+                            delegate { },
+                            140.0f,
+                            30.0f,
+                            true
+                        )
+                    ),
+                    false,
+                    HighLogic.UISkin,
+                    true,
+                    string.Empty
+                );
+            }
+        }
+
+        private void OpenRSSTexturesDownloadPage()
+        {
+            Application.OpenURL("https://github.com/KSP-RO/RSS-Textures/releases/latest");
         }
     }
 }

--- a/Source/TimeWarpFixer.cs
+++ b/Source/TimeWarpFixer.cs
@@ -14,7 +14,6 @@ namespace RealSolarSystem
             fixedTimeWarp = false;
 
             GameSettings.KERBIN_TIME = false;
-            PQSCache.PresetList.SetPreset(PQSCache.PresetList.presets.Count - 1);
         }
 
         public void Update()


### PR DESCRIPTION
Get rid of the RSS_High terrain quality preset and override the stock Low, Default and High presets instead.
Requires Kopernicus release 161 or newer.