### PR TITLE
Turn off finalizeOrbit in Kopernicus configs

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Earth.cfg
@@ -5,7 +5,7 @@
 	{
 		name = Kerbin
 		cbNameLater = Earth
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 1
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Earth.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Moon
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 10
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Moon.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Callisto.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Callisto.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Callisto
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 4
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Callisto.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Europa.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Europa.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Europa
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 9
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Europa.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Ganymede.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Ganymede.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Ganymede
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 13
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Ganymede.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Io.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Io.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Io
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 8
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Io.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Jupiter.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Jupiter/Jupiter.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Jupiter
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 5
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Jupiter.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Deimos.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Deimos.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Deimos
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 12
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Deimos.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Mars.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Mars
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 11
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Mars.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Mars/Phobos.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mars/Phobos.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Phobos
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 7
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Phobos.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Mercury/Mercury.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Mercury
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 2
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Mercury.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Neptune.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Neptune.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Neptune
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 22
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Neptune.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Neptune/Triton.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Triton
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 23
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Triton.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Charon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Charon.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Charon
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 25
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Charon.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Pluto/Pluto.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Pluto
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 24
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Pluto.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Dione.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Dione.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Dione
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 18
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Dione.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Enceladus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Enceladus.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Enceladus
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 16
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Enceladus.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Iapetus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Iapetus.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Iapetus
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 20
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Iapetus.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Mimas.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Mimas.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Mimas
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 15
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Mimas.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Rhea.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Rhea.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Rhea
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 19
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Rhea.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Saturn.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Saturn.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Saturn
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 14
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Saturn.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Tethys.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Tethys.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Tethys
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 17
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Tethys.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Saturn/Titan.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Saturn/Titan.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Titan
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 6
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Titan.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Uranus/Uranus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Uranus/Uranus.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Uranus
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 21
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Uranus.bin
 		Template

--- a/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Venus/Venus.cfg
@@ -4,7 +4,7 @@
 	Body
 	{
 		name = Venus
-		finalizeOrbit = true
+		finalizeOrbit = false
 		flightGlobalsIndex = 3
 		cacheFile = RealSolarSystem/RSSKopernicus/Cache/Venus.bin
 		Template


### PR DESCRIPTION
This causes problems due to the way that the KSP Orbit class is written and the way that Kopernicus attempts to scribble over the meanMotion is not internally consistent.  That would need to be patched and debugged in stock fairly extensively.

The intended behavior also makes it difficult to simulate the Keplerian motion of planets/satellites in RSS since the referenceBody.gravParameter is incorrect and needs to be fixed by "reverse engineering" the effective mu from the meanMotion on the celestial.  This adds a lot of headache.

Even apart from those issues, the buginess remains and causes issues with Keplerian motion, and creates issues that have been seen with detecting SOI encounters in the Earth-Moon system.  Attempting to fix those issues by patching KSP for the meanMotion problems was not successful either, which suggests some of the other tweaking that finalizeOrbit is doing may be buggy as well.

https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/141 https://github.com/Kopernicus/Kopernicus/issues/584

Merging this may not be the right way to fix this though since when I tried disabling this value on a save, the Moon jumped by about 90 degrees in its orbit and a ManeuverNode which was on an encounter was now no longer close.

This change may be save-breaking.