### PR TITLE
Fixed some compatibility issues

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/NavballSwitchAltitude.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/NavballSwitchAltitude.cfg
@@ -1,12 +1,36 @@
 // Compute default surface/orbital navball switching heights.
 @Kopernicus:AFTER[RealSolarSystem]
 {
-    @Body:HAS[@Atmosphere]
+    @Body:HAS[@Atmosphere:HAS[#maxAltitude]]
     {
         // For atmospheric bodies, set to 80% the height of the atmosphere.
         @Properties:HAS[~navballSwitchRadiusMult,~navballSwitchRadiusMultLow]
         {
             navballSwitchRadiusMult = #$../Atmosphere/maxAltitude$
+            @navballSwitchRadiusMult *= 0.8
+            @navballSwitchRadiusMult /= #$radius$
+            navballSwitchRadiusMultLow = #$navballSwitchRadiusMult$
+            @navballSwitchRadiusMultLow *= 0.95
+        }
+    }
+    @Body:HAS[@Atmosphere:HAS[#altitude]]
+    {
+        // For atmospheric bodies, set to 80% the height of the atmosphere.
+        @Properties:HAS[~navballSwitchRadiusMult,~navballSwitchRadiusMultLow]
+        {
+            navballSwitchRadiusMult = #$../Atmosphere/altitude$
+            @navballSwitchRadiusMult *= 0.8
+            @navballSwitchRadiusMult /= #$radius$
+            navballSwitchRadiusMultLow = #$navballSwitchRadiusMult$
+            @navballSwitchRadiusMultLow *= 0.95
+        }
+    }
+    @Body:HAS[@Atmosphere:HAS[#atmosphereDepth]]
+    {
+        // For atmospheric bodies, set to 80% the height of the atmosphere.
+        @Properties:HAS[~navballSwitchRadiusMult,~navballSwitchRadiusMultLow]
+        {
+            navballSwitchRadiusMult = #$../Atmosphere/atmosphereDepth$
             @navballSwitchRadiusMult *= 0.8
             @navballSwitchRadiusMult /= #$radius$
             navballSwitchRadiusMultLow = #$navballSwitchRadiusMult$

--- a/GameData/RealSolarSystem/RSSKopernicusSettings.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicusSettings.cfg
@@ -38,5 +38,21 @@
 	// We do not set the periods because nothing good can come out of
 	// inconsistent orbital elements.
 	
-	!Body,* {}
+	!Body[Sun] {}
+	!Body[Kerbin] {}
+	!Body[Moho] {}
+	!Body[Duna] {}
+	!Body[Eve] {}
+	!Body[Ike] {}
+	!Body[Gilly] {}
+	!Body[Mun] {}
+	!Body[Minmus] {}
+	!Body[Jool] {}
+	!Body[Eeloo] {}
+	!Body[Laythe] {}
+	!Body[Vall] {}
+	!Body[Tylo] {}
+	!Body[Bop] {}
+	!Body[Pol] {}
+	!Body[Dres] {}
 }


### PR DESCRIPTION
1. A small fix in RSSKopernicusSettings.cfg. The previous version removes all the other celestial bodies. The newer version only removes stock celestial bodies. This fix can improve compatibility with other planet mods.
2. A small fix in NavballSwitchAltitude.cfg. `altitude`, `maxAltitude`, and `atmosphereDepth` can all set max atmosphere heights. The previous version can only apply to configs using `maxAltitude`, but if there are configs using `altitude` or `atmosphereDepth`, Module Manager errors will pop in. This new version fixes the issue and improves stability and compatibility.