### PR TITLE
Add NIP 4 and NIP 6 tracking stations

### DIFF
--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -386,6 +386,15 @@
 
                 City2
                 {
+                    name = NIPTrackingStation
+                    objectName = NIP 6 - Vulkanny
+                    lat = 53.101389
+                    lon = 158.359167
+                    alt = 50
+                }
+
+                City2
+                {
                     name = KSATTrackingStation
                     objectName = KSAT - Troll Station
                     lat = -72.0113947

--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -377,6 +377,15 @@
 
                 City2
                 {
+                    name = NIPTrackingStation
+                    objectName = NIP 4 - Yeniseisk
+                    lat = 58.445833
+                    lon = 92.265833
+                    alt = 80
+                }
+
+                City2
+                {
                     name = KSATTrackingStation
                     objectName = KSAT - Troll Station
                     lat = -72.0113947


### PR DESCRIPTION
Add the NIP 4 Yeniseisk tracking station to central Siberia, and the NIP 6 Vulkanny tracking station to the Kamchatka Peninsula, to provide downrange coverage for launches from Soviet Launch sites.