### PR TITLE
Increase moon space low to be more Principia-friendly

### DIFF
--- a/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
+++ b/GameData/RealSolarSystem/RSSKopernicus/Earth/Moon.cfg
@@ -174,7 +174,7 @@
 				inSpaceHighDataValue = 2.5
 				recoveryValue = 3.5
 				flyingAltitudeThreshold = 7000
-				spaceAltitudeThreshold = 200000
+				spaceAltitudeThreshold = 250000
 			}
 
 		}


### PR DESCRIPTION
Increase moon space low altitude to 250 km to make collecting science with Principia a little easier, as discussed in https://github.com/KSP-RO/RP-1/pull/2260