### PR TITLE
Update ScienceDefs.cfg

### DIFF
--- a/GameData/RealSolarSystem/ScienceDefs.cfg
+++ b/GameData/RealSolarSystem/ScienceDefs.cfg
@@ -171,7 +171,7 @@
 
 //You seem determined. Fine. You win.
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[crewReport]]
+@EXPERIMENT_DEFINITION:HAS[#id[crewReport]]
 {
 	@RESULTS
 	{
@@ -328,7 +328,7 @@
 		CharonInSpace = #RSS_Science_CrewReport_CharonInSpace2//It is significantly greyer than the Pluto.
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[evaReport]]
+@EXPERIMENT_DEFINITION:HAS[#id[evaReport]]
 {
 	@RESULTS
 	{
@@ -442,7 +442,7 @@
 	}
 }
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[surfaceSample]]
+@EXPERIMENT_DEFINITION:HAS[#id[surfaceSample]]
 {
 	@RESULTS
 	{
@@ -490,7 +490,7 @@
 		
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[temperatureScan]]
+@EXPERIMENT_DEFINITION:HAS[#id[temperatureScan]]
 {
 	@RESULTS
 	{
@@ -517,7 +517,7 @@
 		CharonSrfLanded = #RSS_Science_TempScan_CharonSrfLanded//As one would assume, the temperature here is low.
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[seismicScan]]
+@EXPERIMENT_DEFINITION:HAS[#id[seismicScan]]
 {
 	@RESULTS
 	{
@@ -534,7 +534,7 @@
 		CeresSrfLanded = #RSS_Science_SeismicScan_CeresSrfLanded//The dwarf planet is mildly cryovolcanic.
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[gravityScan]]
+@EXPERIMENT_DEFINITION:HAS[#id[gravityScan]]
 {
 	@RESULTS
 	{
@@ -571,7 +571,7 @@
 		MercuryInSpace = #RSS_Science_GravityScan_MercuryInSpace//The sensor has difficulty mapping the surface of Mercury due to the tidal influence from the Sun.
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[atmosphereAnalysis]]
+@EXPERIMENT_DEFINITION:HAS[#id[atmosphereAnalysis]]
 {
 	@RESULTS
 	{
@@ -588,7 +588,7 @@
 		JupiterFlyingHigh = #RSS_Science_AtmoAnalysis_JupiterFlyingHigh//The clouds are made from Ammonia ice, 
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[mysteryGoo]]
+@EXPERIMENT_DEFINITION:HAS[#id[mysteryGoo]]
 {
 	@RESULTS
 	{
@@ -636,7 +636,7 @@
 		PlutoInSpace = #RSS_Science_MysteryGoo_PlutoInSpace//While observing the canister, you feel as though something is looking back at you from the shadows of the container.
 	}
 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[mobileMaterialsLab]]
+@EXPERIMENT_DEFINITION:HAS[#id[mobileMaterialsLab]]
 {
 	@RESULTS
 	{


### PR DESCRIPTION
Removed [*] from the experiment definition headers, allowing the science definitions to display properly in modern versions of KSP