### PR TITLE
Implementation of Brazilian ground station network for CommNet

### DIFF
--- a/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
+++ b/GameData/RealSolarSystem/RSS_CommNet_Stations.cfg
@@ -23,6 +23,51 @@
 
                 City2
                 {
+                    name = TrackingStation
+                    objectName = BR - Brasilia
+                    lat = -15.78010
+                    lon = -47.92920
+                    alt = 1100
+                }
+
+                City2
+                {
+                    name = TrackingStation
+                    objectName = BR - Sao Jose dos Campos
+                    lat = -23.21070
+                    lon = -45.87410
+                    alt = 600
+                }
+
+                City2
+                {
+                    name = TrackingStation
+                    objectName = BR - Cachoeira Paulista
+                    lat = -22.68940
+                    lon = -45.00550
+                    alt = 560
+                }
+
+                City2
+                {
+                    name = TrackingStation
+                    objectName = BR - Cuiaba
+                    lat = -15.55530
+                    lon = -56.07010
+                    alt = 165
+                }
+
+                City2
+                {
+                    name = TrackingStation
+                    objectName = BR - Rio de Janeiro
+                    lat = -23.00390
+                    lon = -43.59000
+                    alt = 10
+                }
+
+                City2
+                {
                     name = LaunchSiteTrackingStation
                     objectName = CA - Churchill
                     lat = 58.734167


### PR DESCRIPTION
Expanded the South American ground station network by adding key Brazilian tracking and control facilities. 

Added Stations:
- Brasília: Main military and strategic satellite control center (SGDC).
- São José dos Campos: Primary Satellite Control Center (CCS) for scientific missions.
- Cachoeira Paulista: Vital node for image processing (DGI) and weather data (CPTEC).
- Cuiabá: Strategic telemetry and command station for inland continental coverage.
- Rio de Janeiro: Major commercial telecommunications hub (Embratel Star One).

Technical Accuracy:
Coordinates and altitudes were mapped based on official INPE and Brazilian Air Force (FAB) data to ensure realistic signal occlusion and handover.