### PR TITLE
Add Brazilian launch sites (Alcantara and Natal) to RSS

### DIFF
--- a/GameData/RealSolarSystem/LaunchSites.cfg
+++ b/GameData/RealSolarSystem/LaunchSites.cfg
@@ -50,6 +50,60 @@
 		}
 		Site
 		{
+			name = br_alcantara
+			displayName = #RSS_Site_alcantara_name//BR - Alcantara
+			description = #RSS_Site_cla_desc // The Alcantara Launch Center (CLA) is strategically located near the Equator, offering a significant performance advantage for orbital launches.
+			groundStation = BR - CLA
+			PQSCity
+			{
+				KEYname = KSC
+				changeGrassColor = true
+				latitude = -2.3104
+				longitude = -44.4000
+				repositionRadiusOffset = 203
+				repositionToSphereSurface = false
+				lodvisibleRangeMult = 6
+				reorientFinalAngle = -45.6
+			}
+			PQSMod_MapDecalTangent
+			{
+				radius = 20000
+				heightMapDeformity = 80
+				absoluteOffset = 150
+				absolute = true
+				latitude = -2.3104
+				longitude = -44.4000
+			}
+		}
+		Site
+		{
+			name = br_natal
+			displayName = #RSS_Site_natal_name//BR - Natal
+			description = #RSS_Site_clbi_desc // The Barreira do Inferno Launch Center (CLBI) is Brazil's first spaceport, specialized in suborbital sounding rockets and tracking operations.
+			groundStation = BR - CLBI
+			PQSCity
+			{
+				KEYname = KSC
+				changeGrassColor = true
+				latitude = -5.7683
+				longitude = -35.4069
+				repositionRadiusOffset = 203
+				repositionToSphereSurface = false
+				lodvisibleRangeMult = 6
+				reorientFinalAngle = -54.5931
+			}
+			PQSMod_MapDecalTangent
+			{
+				radius = 20000
+				heightMapDeformity = 80
+				absoluteOffset = 150
+				absolute = true
+				latitude = -5.7683
+				longitude = -35.4069
+			}
+		}
+		Site
+		{
 			name = ca_churchill
 			displayName = #RSS_Site_ca_churchill_name//CA - Churchill
 			description = #RSS_Site_ca_churchill_desc


### PR DESCRIPTION
Added two major Brazilian spaceports with accurate geographical positioning:

- Alcantara (CLA): Positioned at 2.3° S, providing a high-efficiency equatorial launch site for orbital missions.

- Natal (CLBI): Historical site "Barreira do Inferno," configured for sounding rocket operations and suborbital flights.