### PR TITLE
Add a KSPAssembly attribute to assemblyinfo.cs

### DIFF
--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -39,11 +39,12 @@ using System.Runtime.InteropServices;
 #if CIBUILD
 [assembly: AssemblyVersion("@MAJOR@.@MINOR@.@PATCH@.@BUILD@")]
 [assembly: AssemblyFileVersion("@MAJOR@.@MINOR@.@PATCH@.@BUILD@")]
+[assembly: KSPAssembly("RealSolarSystem", @MAJOR@, @MINOR@, @PATCH@)]
 #else
 [assembly: AssemblyVersion("18.5.0.0")]
 [assembly: AssemblyFileVersion("18.5.0.0")]
+[assembly: KSPAssembly("RealSolarSystem", 21, 0, 0)]
 #endif
 
-[assembly: KSPAssembly("RealSolarSystem", 21, 0, 0)]
 [assembly: KSPAssemblyDependency("Kopernicus", 1, 0)]
 [assembly: KSPAssemblyDependency("Kopernicus.Parser", 1, 0)]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -44,5 +44,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("18.5.0.0")]
 #endif
 
+[assembly: KSPAssembly("RealSolarSystem", 21, 0, 0)]
 [assembly: KSPAssemblyDependency("Kopernicus", 1, 0)]
 [assembly: KSPAssemblyDependency("Kopernicus.Parser", 1, 0)]


### PR DESCRIPTION
This allows for other mods to declare a KSPAssemblyDependency on RealSolarSystem. I just did version 21 since that's what I assume the next release will be (because of [this](https://github.com/KSP-RO/RealSolarSystem/pull/320) behemoth), let me know if it should be changed.