### PR TITLE
Use better behavior to get rss settings

### DIFF
--- a/GameData/RealSolarSystem/RealSolarSystem.cfg
+++ b/GameData/RealSolarSystem/RealSolarSystem.cfg
@@ -28,10 +28,10 @@ REALSOLARSYSTEM
 		rate6 = 1000000
 		rate7 = 6000000
 	}
-}
 
-RSSRUNWAYFIX
-{
-	debug = false
-	holdThreshold = 2700
+	RSSRUNWAYFIX
+	{
+		debug = false
+		holdThreshold = 2700
+	}
 }

--- a/Source/CommNetFixer.cs
+++ b/Source/CommNetFixer.cs
@@ -1,5 +1,6 @@
 using CommNet;
 using System;
+using System.Linq;
 using UnityEngine;
 
 namespace RealSolarSystem
@@ -19,23 +20,25 @@ namespace RealSolarSystem
 
                 Debug.Log("[RealSolarSystem] Checking for custom CommNet settings...");
 
-                foreach (ConfigNode RSSSettings in GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM"))
+                ConfigNode node = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault();
+
+                if (node != null)
                 {
-                    RSSSettings.TryGetValue("overrideCommNetParams", ref overrideCommNetParams);
-                    RSSSettings.TryGetValue("enableGroundStations", ref enableExtraGroundStations);
-                    RSSSettings.TryGetValue("occlusionMultiplierAtm", ref occlusionMultiplierInAtm);
-                    RSSSettings.TryGetValue("occlusionMultiplierVac", ref occlusionMultiplierInVac);
-                }
+                    node.TryGetValue("overrideCommNetParams", ref overrideCommNetParams);
+                    node.TryGetValue("enableGroundStations", ref enableExtraGroundStations);
+                    node.TryGetValue("occlusionMultiplierAtm", ref occlusionMultiplierInAtm);
+                    node.TryGetValue("occlusionMultiplierVac", ref occlusionMultiplierInVac);
 
-                if (overrideCommNetParams)
-                {
-                    //  Set the default CommNet parameters for RealSolarSystem.
+                    if (overrideCommNetParams)
+                    {
+                        //  Set the default CommNet parameters for RealSolarSystem.
 
-                    Debug.Log("[RealSolarSystem] Updating the CommNet settings...");
+                        Debug.Log("[RealSolarSystem] Updating the CommNet settings...");
 
-                    HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().enableGroundStations = enableExtraGroundStations;
-                    HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().occlusionMultiplierAtm = occlusionMultiplierInAtm;
-                    HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().occlusionMultiplierVac = occlusionMultiplierInVac;
+                        HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().enableGroundStations = enableExtraGroundStations;
+                        HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().occlusionMultiplierAtm = occlusionMultiplierInAtm;
+                        HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().occlusionMultiplierVac = occlusionMultiplierInVac;
+                    }
                 }
             }
             catch (Exception exceptionStack)

--- a/Source/RSSRunwayFix.cs
+++ b/Source/RSSRunwayFix.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using UnityEngine;
 using static RunwayCollisionHandler;
 
@@ -43,17 +44,16 @@ namespace RealSolarSystem
 
         public void Start()
         {
-            foreach (ConfigNode n in GameDatabase.Instance.GetConfigNodes("RSSRUNWAYFIX"))
-            {
-                if (bool.TryParse(n.GetValue("debug"), out bool bTemp))
-                {
-                    debug = bTemp;
-                }
+            ConfigNode node = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("RSSRUNWAYFIX"));
 
-                if (float.TryParse(n.GetValue("holdThreshold"), out float fTemp))
-                {
-                    holdThreshold = fTemp;
-                }
+            if (bool.TryParse(node.GetValue("debug"), out bool bTemp))
+            {
+                debug = bTemp;
+            }
+
+            if (float.TryParse(node.GetValue("holdThreshold"), out float fTemp))
+            {
+                holdThreshold = fTemp;
             }
 
             GameEvents.onVesselGoOffRails.Add(OnVesselGoOffRails);

--- a/Source/RSSRunwayFix.cs
+++ b/Source/RSSRunwayFix.cs
@@ -46,14 +46,17 @@ namespace RealSolarSystem
         {
             ConfigNode node = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("RSSRUNWAYFIX"));
 
-            if (bool.TryParse(node.GetValue("debug"), out bool bTemp))
+            if (node != null)
             {
-                debug = bTemp;
-            }
+                if (bool.TryParse(node.GetValue("debug"), out bool bTemp))
+                {
+                    debug = bTemp;
+                }
 
-            if (float.TryParse(node.GetValue("holdThreshold"), out float fTemp))
-            {
-                holdThreshold = fTemp;
+                if (float.TryParse(node.GetValue("holdThreshold"), out float fTemp))
+                {
+                    holdThreshold = fTemp;
+                }
             }
 
             GameEvents.onVesselGoOffRails.Add(OnVesselGoOffRails);

--- a/Source/RSSRunwayFix.cs
+++ b/Source/RSSRunwayFix.cs
@@ -44,7 +44,7 @@ namespace RealSolarSystem
 
         public void Start()
         {
-            ConfigNode node = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("RSSRUNWAYFIX"));
+            ConfigNode node = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("RSSRUNWAYFIX"))?.GetNode("RSSRUNWAYFIX");
 
             if (node != null)
             {

--- a/Source/TimeWarpFixer.cs
+++ b/Source/TimeWarpFixer.cs
@@ -25,7 +25,7 @@ namespace RealSolarSystem
             {
                 fixedTimeWarp = true;
 
-                ConfigNode twNode = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("timeWarpRates"));
+                ConfigNode twNode = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("timeWarpRates"))?.GetNode("timeWarpRates");
 
                 if (twNode != null)
                 {

--- a/Source/Watchdogs.cs
+++ b/Source/Watchdogs.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Rendering;
+using System.Linq;
 
 namespace RealSolarSystem
 {
@@ -19,8 +20,7 @@ namespace RealSolarSystem
 
         public void Start()
         {
-            foreach (ConfigNode node in GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM"))
-                rssSettings = node;
+            rssSettings = GameDatabase.Instance.GetConfigNodes("REALSOLARSYSTEM").FirstOrDefault(n => n.HasNode("ClipPlanes"));
 
             GameEvents.onVesselSOIChanged.Add(OnVesselSOIChanged);
             GameEvents.onVesselSituationChange.Add(OnVesselSituationChanged);
@@ -47,7 +47,9 @@ namespace RealSolarSystem
             Camera[] cameras = Camera.allCameras;
             string bodyName = FlightGlobals.getMainBody().name;
 
-            ConfigNode clipPlaneSettings;
+            if (rssSettings == null) return;
+
+            ConfigNode clipPlaneSettings = null;
             if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D11 ||
                 SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12)
             {


### PR DESCRIPTION
The foreach pattern that was previously used is very strange, it sets the node to each of the valid confignodes, ending up with it being set to the last one.

Includes the work I did in https://github.com/CharonSSS/AdvancedPQSTools/pull/5.
Also partially done in https://github.com/KSP-RO/RealSolarSystem/pull/311.