### PR TITLE
Add initial Parallax V3 scatter configs for Earth

### DIFF
--- a/GameData/RealSolarSystem/Compatibility/Parallax/Earth/Earth-ParallaxScatters.cfg
+++ b/GameData/RealSolarSystem/Compatibility/Parallax/Earth/Earth-ParallaxScatters.cfg
@@ -1,0 +1,3507 @@
+@ParallaxScatters:HAS[@Body[Kerbin]]:FOR[RealSolarSystem]:NEEDS[ParallaxContinued,Parallax_StockScatterTextures]
+{
+    !Body[Kerbin] {}
+    Body
+    {
+        name = Kerbin
+	    configVersion = 2
+        filePath = RealSolarSystem/Compatibility/Parallax/Earth/Earth-ParallaxScatters.cfg
+	    Scatter
+	    {
+	    	name = EarthGrass
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/bettergrassUV
+	    	collisionLevel = 0
+			useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -5
+
+				maxRenderableObjectsLOD0 = 2000
+				maxRenderableObjectsLOD1 = 5000
+				maxRenderableObjectsLOD2 = 10000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 50000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/gradient.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbladenrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0400000028
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_SubsurfaceNormalInfluence = 0.300000012
+	    		_SubsurfacePower = 3
+	    		_SubsurfaceIntensity = 1
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.0399999991
+	    		_FresnelColor = 0.0700000003,0.0700000003,0.0700000003,1
+	    		_Color = 1.300, 1.400, 1.000, 1.000
+	    		_SubsurfaceColor = 0.400000006,0.5,0.200000003,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = TWO_SIDED
+	    			name = SUBSURFACE_SCATTERING
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 9
+	    		spawnChance = 0.9
+	    		range = 2500
+	    		populationMultiplier = 550
+	    		minScale = 0.100000001,0.0700000003,0.100000001
+	    		maxScale = 0.119999997,0.100000001,0.119999997
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.34
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300001949
+	    		minAltitude = -5
+	    		maxAltitude = 5000
+	    		altitudeFadeRange = 40
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/bettergrassUV2
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/grassbillboard
+	    				range = 60
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbillboardnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.025
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_SubsurfaceNormalInfluence = 0.300000012
+	    					_SubsurfacePower = 3
+	    					_SubsurfaceIntensity = 1
+	    					_WindScale = 0.00800000038
+	    					_WindHeightStart = 2.1400001
+	    					_WindHeightFactor = 1.62
+	    					_WindSpeed = 2.0999999
+	    					_WindIntensity = 0.0399999991
+	    					_Cutoff = 0.600000024
+	    					_FresnelColor = 0.0700000003,0.0700000003,0.0700000003,1
+	    					_Color = 1.300, 1.400, 1.000, 1.000
+	    					_SubsurfaceColor = 0.400000006,0.5,0.200000003,1
+	    					_CullMode = 0
+	    					Keywords
+	    					{
+	    						name = TWO_SIDED
+	    						name = SUBSURFACE_SCATTERING
+	    						name = WIND
+	    						name = ALPHA_CUTOFF
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Tundra
+	    			name = Desert
+	    			name = Ice Caps
+	    			name = Water
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = EarthGrassTall
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/bettergrassUV
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -15
+
+				maxRenderableObjectsLOD0 = 2000
+				maxRenderableObjectsLOD1 = 5000
+				maxRenderableObjectsLOD2 = 10000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 50000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/gradient.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbladenrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0300000012
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.0399999991
+	    		_SubsurfaceNormalInfluence = 0.300000012
+	    		_SubsurfacePower = 3
+	    		_SubsurfaceIntensity = 1
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1.500, 1.500, 1.200, 1.000
+	    		_SubsurfaceColor = 0.400000006,0.5,0.200000003,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = WIND
+	    			name = SUBSURFACE_SCATTERING
+                    name = TWO_SIDED
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 1.65900004
+	    		spawnChance = 0.9
+	    		range = 2500
+	    		populationMultiplier = 340
+	    		minScale = 0.0399999991,0.100000001,0.0399999991
+	    		maxScale = 0.159999996,0.159999996,0.159999996
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300000787
+	    		minAltitude = -5
+	    		maxAltitude = 2500
+	    		altitudeFadeRange = 40
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/bettergrassUV2
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/grassbillboard
+	    				range = 80
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassbillboardnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.025
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_SubsurfaceNormalInfluence = 0.300000012
+	    					_SubsurfacePower = 3
+	    					_SubsurfaceIntensity = 1
+	    					_WindScale = 0.00800000038
+	    					_WindHeightStart = 2.1400001
+	    					_WindHeightFactor = 1.62
+	    					_WindSpeed = 2.0999999
+	    					_WindIntensity = 0.0399999991
+	    					_Cutoff = 0.54
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 1.500, 1.500, 1.200, 1.000
+	    					_SubsurfaceColor = 0.400000006,0.5,0.200000003,1
+	    					_CullMode = 0
+	    					Keywords
+	    					{
+	    						name = TWO_SIDED
+	    						name = SUBSURFACE_SCATTERING
+	    						name = WIND
+	    						name = ALPHA_CUTOFF
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Tundra
+	    			name = Desert
+	    			name = Ice Caps
+	    			name = Water
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = EarthDryGrass
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/lushgrass0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 2000
+				maxRenderableObjectsLOD1 = 5000
+				maxRenderableObjectsLOD2 = 10000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 40000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertgrass.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertgrassnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.00200000009
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1.10000002,1.14999998,1.04999995,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 3.14159012
+	    		spawnChance = 0.9
+	    		range = 5000
+	    		populationMultiplier = 750
+	    		minScale = 0.0399999991,0.0399999991,0.0399999991
+	    		maxScale = 0.180000007,0.100000001,0.180000007
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.600000024
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300000787
+	    		minAltitude = -20
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/lushgrass1
+	    				range = 50
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/lushgrass2
+	    				range = 100
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertgrass.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertgrassnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.0500000007
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_Cutoff = 0.5
+	    					_WindScale = 0.00800000038
+	    					_WindHeightStart = 2.1400001
+	    					_WindHeightFactor = 1.62
+	    					_WindSpeed = 2.0999999
+	    					_WindIntensity = 0.00200000009
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 1.10000002,1.14999998,1.04999995,1
+	    					_CullMode = 0
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = TWO_SIDED
+	    						name = WIND
+	    						name = BILLBOARD_USE_MESH_NORMALS
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = EarthFern
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/fern
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -15
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 90000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/fern.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/fernnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.008
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.1
+	    		_WindIntensity = 0.003
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.699999988,0.670000017,0.639999986,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 0.419999987
+	    		spawnChance = 0.55
+	    		range = 1000
+	    		populationMultiplier = 175
+	    		minScale = 0.0399999991,0.0399999991,0.0399999991
+	    		maxScale = 0.0799999982,0.0799999982,0.0799999982
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.600000024
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300000787
+	    		minAltitude = -5
+	    		maxAltitude = 2500
+	    		altitudeFadeRange = 30
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/fern
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/fern
+	    				range = 50
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Daisy
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/daisyPatchLOD0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -15
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 60000
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 4
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/daisy.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/daisynrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 0.300000012
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.100000001
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 0.111110002
+	    		spawnChance = 0.22
+	    		range = 1000
+	    		populationMultiplier = 250
+	    		minScale = 0.300000012,0.300000012,0.300000012
+	    		maxScale = 0.400000006,0.400000006,0.400000006
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.629999995
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300001949
+	    		minAltitude = -5
+	    		maxAltitude = 2500
+	    		altitudeFadeRange = 40
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/daisyPatchLOD1
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/daisyPatchLOD2
+	    				range = 50
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/daisybillboard.dds
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Roses
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/roses
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 18
+	    		frustumCullingScreenMargin = -15
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 40000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 5
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/roses.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/rosesnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.008
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.1
+	    		_WindIntensity = 0.002
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.699999988,0.670000017,0.639999986,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 10.1111097
+	    		spawnChance = 0.22
+	    		range = 1000
+	    		populationMultiplier = 20
+	    		minScale = 0.0399999991,0.0399999991,0.0399999991
+	    		maxScale = 0.0700000003,0.0700000003,0.0700000003
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.300000787
+	    		minAltitude = -5
+	    		maxAltitude = 2500
+	    		altitudeFadeRange = 20
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/roses
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/roses
+	    				range = 50
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Tundra
+	    			name = Desert
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = EarthShrub
+	    	model = Parallax_StockScatterTextures/Models/Laythe/cottonlod0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 10
+	    		frustumCullingScreenMargin = -15
+
+				maxRenderableObjectsLOD0 = 2000
+				maxRenderableObjectsLOD1 = 5000
+				maxRenderableObjectsLOD2 = 10000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 70000
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/shrub.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Laythe/PluginData/cottonnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 0.0199999996
+	    		_WindHeightFactor = 1.62
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 1.29999995
+	    		_Cutoff = 0.5
+	    		_SubsurfaceNormalInfluence = 0.5
+	    		_SubsurfacePower = 2
+	    		_SubsurfaceIntensity = 1
+	    		_FresnelColor = 0.150000006,0.150000006,0.150000006,1
+	    		_Color = 0.699999988,0.699999988,0.699999988,1
+	    		_SubsurfaceColor = 0.5,0.300000012,0.5,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = WIND
+	    			name = ALPHA_CUTOFF
+	    			name = SUBSURFACE_SCATTERING
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 0.333900005
+	    		spawnChance = 0.9
+	    		range = 2500
+	    		populationMultiplier = 343
+	    		minScale = 3,3,3
+	    		maxScale = 3.5,3.5,3.5
+	    		scaleRandomness = 0.899999976
+	    		cutoffScale = 0.25
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.850000024
+	    		maxNormalDeviance = 0.500002146
+	    		minAltitude = 1
+	    		maxAltitude = 2510
+	    		altitudeFadeRange = 46
+	    		alignToTerrainNormal = True
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Laythe/cottonlod1
+	    				range = 20
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Laythe/cottonlod2
+	    				range = 50
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Water
+	    			name = Ice Caps
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = OakTree
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/oakTrunkLOD0
+	    	collisionLevel = 2
+			useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = True
+	    		frequency = 670
+	    		octaves = 6
+	    		lacunarity = 2
+	    		seed = 36
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTrunk.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTrunknrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 1.6
+	    		_WindSpeed = 1.10000002
+	    		_WindIntensity = 0.008
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 62.14
+	    		spawnChance = 0.35
+	    		range = 20000
+	    		populationMultiplier = 12
+	    		minScale = 1.1,1.1,1.1
+	    		maxScale = 1.95,1.95,1.95
+	    		scaleRandomness = 0.6
+	    		cutoffScale = 0.80
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000715
+	    		minAltitude = 3
+	    		maxAltitude = 2000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/oakTrunkLOD1
+	    				range = 100
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTrunk.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTrunknrm.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 1,1,1,1
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    					}
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/oakTrunkLOD2
+	    				range = 1000
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakBillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakBillboardnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.015
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_Cutoff = 0.6
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 0.800, 0.800, 0.650, 1.000
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = BILLBOARD
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Water
+	    			name = Ice Caps
+	    			name = Desert
+}
+	    	}
+	    }
+	    SharedScatter
+	    {
+	    	name = OakTreeTop
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/oakLeavesLOD1
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	parentName = OakTree
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakLeaves.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakLeavesnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_ThicknessMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakthickness.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.18
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 0.600000024
+	    		_WindSpeed = 1.10000002
+	    		_WindIntensity = 0.200000003
+	    		_SubsurfaceNormalInfluence = 0.5
+	    		_SubsurfacePower = 12
+	    		_SubsurfaceIntensity = 1.6
+	    		_SubsurfaceMin = 0.381
+	    		_SubsurfaceMax = 1
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.875,0.9,0.75,1
+	    		_SubsurfaceColor = 0.400000006,0.5,0.200000003,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = WIND
+	    			name = SUBSURFACE_USE_THICKNESS_TEXTURE
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/oakLeavesLOD1
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/oakLeavesLOD2
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTreeTop.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/oakTreeTopnrm.dds
+	    					_Color = 0.800, 0.800, 0.650, 1.000
+	    					_Cutoff = 0.7
+                            _SpecularIntensity = 0.0
+	    				}
+	    			}
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = PineTree
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/pinetrunk0
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexCellular
+	    		inverted = False
+	    		frequency = 700
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 38
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/trunk.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/trunknrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 69.6900024
+	    		spawnChance = 0.25
+	    		range = 20000
+	    		populationMultiplier = 20
+	    		minScale = 2.79999995,2.79999995,2.79999995
+	    		maxScale = 4.8,7,4.8
+	    		scaleRandomness = 0.400000006
+	    		cutoffScale = 0.7
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000715
+	    		minAltitude = 100
+	    		maxAltitude = 5000
+	    		altitudeFadeRange = 100
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/pinetrunk1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/pine2
+	    				range = 1000
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cutoutpine.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/trunknrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.0
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_Cutoff = 0.5
+	    					_WindScale = 0.0799999982
+	    					_WindHeightStart = 0.0500000007
+	    					_WindHeightFactor = 2
+	    					_WindSpeed = 0
+	    					_WindIntensity = 0
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 1,1,1,1
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = TWO_SIDED
+	    						name = WIND
+	    						name = BILLBOARD_USE_MESH_NORMALS
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Water
+	    			name = Ice Caps
+	    			name = Desert
+}
+	    	}
+	    }
+	    SharedScatter
+	    {
+	    	name = PineTreeTop
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/pineleaves1
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	parentName = PineTree
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/spruce.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/sprucenrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.00800000038
+	    		_WindHeightStart = 0.140000001
+	    		_WindHeightFactor = 0.00999999978
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.5
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.5,0.600000024,0.800000012,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/pineleaves1
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/pine2Top
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cutoutpine.dds
+                            _SpecularIntensity = 0.0
+	    				}
+	    			}
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = PalmTree
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetrunk
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 8000
+	    		octaves = 6
+	    		lacunarity = 2
+	    		seed = 2
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtree.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreenrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.00400000019
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 9.99999975E-05
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 27
+	    		spawnChance = 0.85
+	    		range = 20000
+	    		populationMultiplier = 8
+	    		minScale = 0.8,0.8,0.8
+	    		maxScale = 1.25,1.25,1.25
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000715
+	    		minAltitude = 3
+	    		maxAltitude = 3000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetrunk
+	    				range = 100
+	    				MaterialOverride
+	    				{
+
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreebillboard
+	    				range = 1000
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreebillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreebillboardnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.01
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_Cutoff = 0.35
+	    					_WindScale = 0.0799999982
+	    					_WindHeightStart = 0.0500000007
+	    					_WindHeightFactor = 2
+	    					_WindSpeed = 0
+	    					_WindIntensity = 0
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 0.800000012,0.800000012,0.550000012,1
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = TWO_SIDED
+	    						name = WIND
+	    						name = BILLBOARD_USE_MESH_NORMALS
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Grasslands
+	    			name = Water
+	    			name = Ice Caps
+	    			name = Desert
+	    			name = Mountains
+	    			name = Forest
+	    			name = Tundra
+	    			name = Taiga
+}
+	    	}
+	    }
+	    SharedScatter
+	    {
+	    	name = PalmTreeTop
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/palmtreeleaves
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	parentName = PalmTree
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmleaf.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmleafnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.300000012
+	    		_WindScale = 0.00400000019
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 0.620000005
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.0500000007
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.700, 0.700, 0.550, 1.000
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreeleaves
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetopbillboard
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreetopbillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreetopbillboardnrm.dds
+	    					_Color = 0.800000012,0.800000012,0.550000012,1
+	    				}
+	    			}
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = DesertPalmTree
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetrunk
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPolkaDot
+	    		inverted = False
+	    		frequency = 1000
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 2
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtree.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreenrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.00400000019
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 9.99999975E-05
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 27
+	    		spawnChance = 0.25
+	    		range = 20000
+	    		populationMultiplier = 4
+	    		minScale = 0.8,0.8,0.8
+	    		maxScale = 1.25,1.25,1.25
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000715
+	    		minAltitude = 3
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetrunk
+	    				range = 100
+	    				MaterialOverride
+	    				{
+
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreebillboard
+	    				range = 1000
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreebillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreebillboardnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularPower = 15
+	    					_SpecularIntensity = 0.01
+	    					_FresnelPower = 3
+	    					_EnvironmentMapFactor = 1
+	    					_BumpScale = 1
+	    					_Hapke = 1
+	    					_Cutoff = 0.35
+	    					_WindScale = 0.0799999982
+	    					_WindHeightStart = 0.0500000007
+	    					_WindHeightFactor = 2
+	    					_WindSpeed = 0
+	    					_WindIntensity = 0
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_Color = 0.800000012,0.800000012,0.550000012,1
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = TWO_SIDED
+	    						name = WIND
+	    						name = BILLBOARD_USE_MESH_NORMALS
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    SharedScatter
+	    {
+	    	name = DesertPalmTreeTop
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/palmtreeleaves
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	parentName = DesertPalmTree
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -400
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 8000
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmleaf.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmleafnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.300000012
+	    		_WindScale = 0.00400000019
+	    		_WindHeightStart = 2.1400001
+	    		_WindHeightFactor = 0.620000005
+	    		_WindSpeed = 2.0999999
+	    		_WindIntensity = 0.0500000007
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 0.700, 0.700, 0.550, 1.000
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreeleaves
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/palmtreetopbillboard
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreetopbillboard.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/palmtreetopbillboardnrm.dds
+	    					_Color = 0.800000012,0.800000012,0.550000012,1
+	    				}
+	    			}
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Kelp
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/kelplod0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 50
+	    		frustumCullingScreenMargin = -50
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 900
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1000
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/kelp.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/kelpnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.100000001
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 20
+	    		spawnChance = 0
+	    		range = 1
+	    		populationMultiplier = 4
+	    		minScale = 1,1,1
+	    		maxScale = 6,6,6
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 2
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 4.99999142
+	    		minAltitude = -10000
+	    		maxAltitude = -100
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/kelplod1
+	    				range = 75
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/kelplod1
+	    				range = 150
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		// Disabled on RSS Earth: underwater scatters add cost but are rarely useful because RSS gameplay does not involve diving.
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Reeds
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/reed
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 300
+	    		frustumCullingScreenMargin = -10
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 900
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1000
+	    		octaves = 2
+	    		lacunarity = 2
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/underseagreen.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/reedsnrm.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0500000007
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 21
+	    		spawnChance = 0
+	    		range = 1
+	    		populationMultiplier = 2
+	    		minScale = 0.5,0.5,0.5
+	    		maxScale = 1,1,1
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 2
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 1
+	    		minAltitude = -1000
+	    		maxAltitude = -140
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/reedLOD1
+	    				range = 125
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/reedLOD1
+	    				range = 250
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		// Disabled on RSS Earth: underwater scatters add cost but are rarely useful because RSS gameplay does not involve diving.
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Seaweed
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/kerbinseaweed0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 60.0000038
+	    		frustumCullingScreenMargin = -40
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 900
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 2000
+	    		octaves = 6
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/seaweed.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/seaweednrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0300000012
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 25.3199997
+	    		spawnChance = 0
+	    		range = 1
+	    		populationMultiplier = 25
+	    		minScale = 10,10,10
+	    		maxScale = 20,20,20
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 2
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 1
+	    		minAltitude = -3000
+	    		maxAltitude = -110
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/kerbinseaweed1
+	    				range = 175
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/kerbinseaweed1
+	    				range = 290
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		// Disabled on RSS Earth: underwater scatters add cost but are rarely useful because RSS gameplay does not involve diving.
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = Seagrass
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/seagrass0
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 10
+	    		frustumCullingScreenMargin = -10
+	    		maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 900
+				maxRenderableObjectsLOD2 = 2500
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 2000
+	    		octaves = 4
+	    		lacunarity = 2
+	    		seed = 0
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/PluginData/sand.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/grassnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.0250000004
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 69
+	    		spawnChance = 0
+	    		range = 1
+	    		populationMultiplier = 450
+	    		minScale = 1,1,1
+	    		maxScale = 2,2,2
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.5
+	    		steepPower = 1
+	    		steepContrast = 1
+	    		steepMidpoint = 0.5
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = -1000
+	    		maxAltitude = -10
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/seagrass1
+	    				range = 40
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/seagrass1
+	    				range = 60
+	    				MaterialOverride
+	    				{
+	    					_CullMode = 2
+	    				}
+	    			}
+	    		}
+	    		// Disabled on RSS Earth: underwater scatters add cost but are rarely useful because RSS gameplay does not involve diving.
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = HugeCactus
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/hugecacti0
+	    	collisionLevel = 4
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 600
+	    		octaves = 6
+	    		lacunarity = 2
+	    		seed = 884
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 124.119995
+	    		spawnChance = 0.02
+	    		range = 5000
+	    		populationMultiplier = 2
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/hugecacti1
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/hugecacti2
+	    				range = 400
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = LargeCactus
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacti0
+	    	collisionLevel = 3
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 110.119995
+	    		spawnChance = 0.04
+	    		range = 5000
+	    		populationMultiplier = 2
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacti1
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacti2
+	    				range = 400
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = MedCactus
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacti0
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 111.119995
+	    		spawnChance = 0.04
+	    		range = 3000
+	    		populationMultiplier = 2
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacti1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacti2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = SmallCactus
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacti0
+	    	collisionLevel = 1
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 112.119995
+	    		spawnChance = 0.05
+	    		range = 2000
+	    		populationMultiplier = 2
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacti1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacti2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = TinyCactus
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/tinycacti0
+	    	collisionLevel = 1
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 10
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 500
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 2000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 113.119995
+	    		spawnChance = 0.1
+	    		range = 2000
+	    		populationMultiplier = 1
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/tinycacti1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/tinycacti2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = LargeCactiCluster
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacticluster0
+	    	collisionLevel = 3
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 168.119995
+	    		spawnChance = 0.1
+	    		range = 5000
+	    		populationMultiplier = 1
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacticluster1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/largecacticluster2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = MedCactiCluster
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacticluster0
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 167.119995
+	    		spawnChance = 0.2
+	    		range = 3000
+	    		populationMultiplier = 1
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacticluster1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/medcacticluster2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = SmallCactiCluster
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacticluster0
+	    	collisionLevel = 1
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -35
+
+				maxRenderableObjectsLOD0 = 1000
+				maxRenderableObjectsLOD1 = 2000
+				maxRenderableObjectsLOD2 = 3000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactus.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/cactusnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularPower = 15
+	    		_SpecularIntensity = 0.01
+	    		_FresnelPower = 3
+	    		_EnvironmentMapFactor = 1
+	    		_BumpScale = 1
+	    		_Hapke = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_Color = 1,1,1,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 166.119995
+	    		spawnChance = 0.2
+	    		range = 2000
+	    		populationMultiplier = 1
+	    		minScale = 2,2,2
+	    		maxScale = 3,3,3
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.550000012
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.500000358
+	    		minAltitude = 5
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacticluster1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/smallcacticluster2
+	    				range = 200
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Mountains
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    		}
+	    	}
+	    }
+	    Scatter
+	    {
+	    	name = BaobabTreeTrunk
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobabtrunk0
+	    	collisionLevel = 2
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -200
+	    		maxRenderableObjectsLOD0 = 400
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 5000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    		subdivisionRangeMode = noSubdivision
+	    	}
+	    	DistributionNoise
+	    	{
+	    		noiseType = simplexPerlin
+	    		inverted = False
+	    		frequency = 1
+	    		octaves = 1
+	    		lacunarity = 1
+	    		seed = 1
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertwood.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/desertwoodnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularIntensity = 0.0
+	    		_SpecularPower = 15
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_FresnelPower = 3
+	    		_Transmission = 1
+	    		_BumpScale = 1
+	    		_EnvironmentMapFactor = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_Color = 1,1,1,1
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_CullMode = 2
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		seed = 12.3000002
+	    		spawnChance = 0.2
+	    		range = 20000
+	    		populationMultiplier = 4
+	    		minScale = 1.049999982,1.049999982,1.049999982
+	    		maxScale = 2,2,2
+	    		scaleRandomness = 0.5
+	    		cutoffScale = 0.25
+	    		steepPower = 8
+	    		steepContrast = 4.5
+	    		steepMidpoint = 0.731000006
+	    		maxNormalDeviance = 0.5
+	    		minAltitude = 50
+	    		maxAltitude = 4000
+	    		altitudeFadeRange = 10
+	    		alignToTerrainNormal = False
+	    		coloredByTerrain = false
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobabtrunk1
+	    				range = 100
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobabtreebillboard
+	    				range = 1000
+	    				Material
+	    				{
+	    					shader = Custom/ParallaxInstancedSolid
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobabcutout.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobabcutoutnrm.dds
+	    					_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    					_SpecularIntensity = 0.05
+	    					_SpecularPower = 15
+	    					_Hapke = 1
+	    					_Cutoff = 0.5
+	    					_FresnelPower = 3
+	    					_Transmission = 1
+	    					_BumpScale = 1
+	    					_EnvironmentMapFactor = 1
+	    					_WindScale = 0.0799999982
+	    					_WindHeightStart = 0.0500000007
+	    					_WindHeightFactor = 2
+	    					_WindSpeed = 0
+	    					_WindIntensity = 0
+	    					_Color = 1,1,1,1
+	    					_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    					_CullMode = 2
+	    					Keywords
+	    					{
+	    						name = ALPHA_CUTOFF
+	    						name = TWO_SIDED
+	    						name = WIND
+	    						name = BILLBOARD_USE_MESH_NORMALS
+	    					}
+	    				}
+	    			}
+	    		}
+	    		BiomeBlacklist
+	    		{
+	    			name = Grasslands
+	    			name = Water
+	    			name = Ice Caps
+	    			    			name = Forest
+	    			name = Tundra
+	    			name = Taiga
+}
+	    	}
+	    }
+	    SharedScatter
+	    {
+	    	name = BaobabTreeTop
+	    	model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobableaves
+	    	parentName = BaobabTreeTrunk
+	    	collisionLevel = 0
+	    	useCraftPositionForDistanceCulling = True
+	    	Optimizations
+	    	{
+	    		frustumCullingStartRange = 20
+	    		frustumCullingScreenMargin = -15
+	    		maxRenderableObjectsLOD0 = 300
+				maxRenderableObjectsLOD1 = 1000
+				maxRenderableObjectsLOD2 = 5000
+	    	}
+	    	SubdivisionSettings
+	    	{
+	    	}
+	    	DistributionNoise
+	    	{
+	    	}
+	    	Material
+	    	{
+	    		shader = Custom/ParallaxInstancedSolid
+	    		_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobableaf.dds
+	    		_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobableafnrm.dds
+	    		_WindMap = Parallax_StockScatterTextures/PluginData/grassuv2.dds
+	    		_SpecularIntensity = 0.100000001
+	    		_SpecularPower = 15
+	    		_Hapke = 1
+	    		_Cutoff = 0.5
+	    		_FresnelPower = 3
+	    		_Transmission = 1
+	    		_BumpScale = 1
+	    		_EnvironmentMapFactor = 1
+	    		_WindScale = 0.0799999982
+	    		_WindHeightStart = 0.0500000007
+	    		_WindHeightFactor = 2
+	    		_WindSpeed = 0
+	    		_WindIntensity = 0
+	    		_Color = 1,1,1,1
+	    		_FresnelColor = 0.0500000007,0.0500000007,0.0500000007,1
+	    		_CullMode = 0
+	    		Keywords
+	    		{
+	    			name = ALPHA_CUTOFF
+	    			name = TWO_SIDED
+	    			name = WIND
+	    		}
+	    	}
+	    	Distribution
+	    	{
+	    		LODs
+	    		{
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobableaves
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    				}
+	    			}
+	    			LOD
+	    			{
+	    				model = Parallax_StockScatterTextures/Models/Kerbin/Cacti/baobabtreetop
+	    				range = 0
+	    				MaterialOverride
+	    				{
+	    					_MainTex = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobabcutouttop.dds
+	    					_BumpMap = Parallax_StockScatterTextures/Textures/Kerbin/PluginData/baobabcutouttopnrm.dds
+	    				}
+	    			}
+	    		}
+	    	}
+	    }
+        Scatter
+        {
+            name = SmallRocks
+            model = Parallax_StockScatterTextures/Models/Mun/clusterofsmalls
+            collisionLevel = 0
+            useCraftPositionForDistanceCulling = True
+            Optimizations
+            {
+            	frustumCullingStartRange = 20
+            	frustumCullingScreenMargin = -10
+            	maxRenderableObjectsLOD0 = 1000
+            	maxRenderableObjectsLOD1 = 2000
+            	maxRenderableObjectsLOD2 = 5000
+            }
+            SubdivisionSettings
+            {
+                subdivisionRangeMode = noSubdivision
+            }
+            DistributionNoise
+            {
+                noiseType = simplexPerlin
+                inverted = False
+                frequency = 180000
+                octaves = 6
+                lacunarity = 2
+                seed = 1
+            }
+            Material
+            {
+                shader = Custom/ParallaxInstancedSolid
+                _MainTex = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlas.dds
+                _BumpMap = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlasnrm.dds
+                _SpecularPower = 80
+                _SpecularIntensity = 0.0813980028
+                _FresnelPower = 4
+                _EnvironmentMapFactor = 1
+                _BumpScale = 1
+                _Hapke = 0.44
+                _FresnelColor = 0.0799999982,0.0799999982,0.0799999982,1
+                _Color = 1.10000002,1.10000002,1.10000002,1
+                _CullMode = 2
+                Keywords
+                {
+                }
+            }
+            Distribution
+            {
+                seed = 0
+                spawnChance = 0.20
+                range = 2500
+                populationMultiplier = 10
+                minScale = 0.05,0.05,0.05
+                maxScale = 0.2,0.2,0.2
+                scaleRandomness = 0.5
+                cutoffScale = 0.5
+                steepPower = 8
+                steepContrast = 4.5
+                steepMidpoint = 0.731000006
+                maxNormalDeviance = 0.130000278
+                minAltitude = -5
+                maxAltitude = 10000
+                altitudeFadeRange = 10
+                alignToTerrainNormal = True
+                coloredByTerrain = false
+                LODs
+                {
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterofsmalls2
+                        range = 30
+                        MaterialOverride
+                        {
+                        }
+                    }
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterofsmalls3
+                        range = 100
+                        MaterialOverride
+                        {
+                        }
+                    }
+                }
+            	    		BiomeBlacklist
+	    		{
+	    			name = Water
+	    			name = Ice Caps
+	    		}
+}
+        }
+        Scatter
+        {
+            name = MedRocks
+            model = Parallax_StockScatterTextures/Models/Mun/clustermed
+            collisionLevel = 0
+            useCraftPositionForDistanceCulling = True
+            Optimizations
+            {
+            	frustumCullingStartRange = 20
+            	frustumCullingScreenMargin = -13
+            	maxRenderableObjectsLOD0 = 1000
+            	maxRenderableObjectsLOD1 = 2000
+            	maxRenderableObjectsLOD2 = 5000
+            }
+            SubdivisionSettings
+            {
+                subdivisionRangeMode = noSubdivision
+            }
+            DistributionNoise
+            {
+                noiseType = simplexCellular
+                inverted = False
+                frequency = 1000
+                octaves = 6
+                lacunarity = 2
+                seed = 1
+            }
+            Material
+            {
+                shader = Custom/ParallaxInstancedSolid
+                _MainTex = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlas.dds
+                _BumpMap = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlasnrm.dds
+                _SpecularPower = 80
+                _SpecularIntensity = 0.0813980028
+                _FresnelPower = 4
+                _EnvironmentMapFactor = 1
+                _BumpScale = 1
+                _Hapke = 0.44
+                _FresnelColor = 0.0799999982,0.0799999982,0.0799999982,1
+                _Color = 1.10000002,1.10000002,1.10000002,1
+                _CullMode = 2
+                Keywords
+                {
+                }
+            }
+            Distribution
+            {
+                seed = 12
+                spawnChance = 0.20
+                range = 5000
+                populationMultiplier = 1
+                minScale = 0.25,0.25,0.25
+                maxScale = 1.0,1.0,1.0
+                scaleRandomness = 0.5
+                cutoffScale = 0.7
+                steepPower = 8
+                steepContrast = 4.5
+                steepMidpoint = 0.731000006
+                maxNormalDeviance = 0.150000304
+                minAltitude = -5
+                maxAltitude = 10000
+                altitudeFadeRange = 10
+                alignToTerrainNormal = True
+                coloredByTerrain = false
+                LODs
+                {
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clustermed2
+                        range = 50
+                        MaterialOverride
+                        {
+                        }
+                    }
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clustermed3
+                        range = 100
+                        MaterialOverride
+                        {
+                        }
+                    }
+                }
+            	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+}
+        }
+        Scatter
+        {
+            name = LargeRocks
+            model = Parallax_StockScatterTextures/Models/Mun/clusterlarge
+            collisionLevel = 3
+            useCraftPositionForDistanceCulling = True
+            Optimizations
+            {
+            	frustumCullingStartRange = 20
+            	frustumCullingScreenMargin = -20
+            	maxRenderableObjectsLOD0 = 1000
+            	maxRenderableObjectsLOD1 = 2000
+            	maxRenderableObjectsLOD2 = 5000
+            }
+            SubdivisionSettings
+            {
+                subdivisionRangeMode = noSubdivision
+            }
+            DistributionNoise
+            {
+                noiseType = simplexCellular
+                inverted = True
+                frequency = 40000
+                octaves = 6
+                lacunarity = 2
+                seed = 1
+            }
+            Material
+            {
+                shader = Custom/ParallaxInstancedSolid
+                _MainTex = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlas.dds
+                _BumpMap = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlasnrm.dds
+                _SpecularPower = 80
+                _SpecularIntensity = 0.0813980028
+                _FresnelPower = 4
+                _EnvironmentMapFactor = 1
+                _BumpScale = 1
+                _Hapke = 0.44
+                _FresnelColor = 0.0799999982,0.0799999982,0.0799999982,1
+                _Color = 1.10000002,1.10000002,1.10000002,1
+                _CullMode = 2
+                Keywords
+                {
+                }
+            }
+            Distribution
+            {
+                seed = 15
+                spawnChance = 0.2
+                range = 20000
+                populationMultiplier = 1
+                minScale = 0.4,0.4,0.4
+                maxScale = 3.0,3.0,3.0
+                scaleRandomness = 0.5
+                cutoffScale = 0.75
+                steepPower = 8
+                steepContrast = 4.5
+                steepMidpoint = 0.731000006
+                maxNormalDeviance = 0.200000346
+                minAltitude = -5
+                maxAltitude = 10000
+                altitudeFadeRange = 10
+                alignToTerrainNormal = True
+                coloredByTerrain = false
+                LODs
+                {
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterlarge2
+                        range = 100
+                        MaterialOverride
+                        {
+                        }
+                    }
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterlarge3
+                        range = 300
+                        MaterialOverride
+                        {
+                        }
+                    }
+                }
+            	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+}
+        }
+        Scatter
+        {
+            name = HugeRocks
+            model = Parallax_StockScatterTextures/Models/Mun/clusterhuge
+            collisionLevel = 4
+            useCraftPositionForDistanceCulling = True
+            Optimizations
+            {
+            	frustumCullingStartRange = 20
+            	frustumCullingScreenMargin = -50
+            	maxRenderableObjectsLOD0 = 1000
+            	maxRenderableObjectsLOD1 = 2000
+            	maxRenderableObjectsLOD2 = 5000
+            }
+            SubdivisionSettings
+            {
+                subdivisionRangeMode = noSubdivision
+            }
+            DistributionNoise
+            {
+                noiseType = simplexPerlin
+                inverted = False
+                frequency = 180000
+                octaves = 6
+                lacunarity = 2
+                seed = 1
+            }
+            Material
+            {
+                shader = Custom/ParallaxInstancedSolid
+                _MainTex = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlas.dds
+                _BumpMap = Parallax_StockScatterTextures/Textures/Mun/PluginData/rockatlasnrm.dds
+                _SpecularPower = 80
+                _SpecularIntensity = 0.0813980028
+                _FresnelPower = 4
+                _EnvironmentMapFactor = 1
+                _BumpScale = 1
+                _Hapke = 0.44
+                _FresnelColor = 0.0799999982,0.0799999982,0.0799999982,1
+                _Color = 1.10000002,1.10000002,1.10000002,1
+                _CullMode = 2
+                Keywords
+                {
+                }
+            }
+            Distribution
+            {
+                seed = 25
+                spawnChance = 0.1
+                range = 20000
+                populationMultiplier = 1
+                minScale = 0.5,0.5,0.5
+                maxScale = 5.0,5.0,5.0
+                scaleRandomness = 0.5
+                cutoffScale = 0.6
+                steepPower = 8
+                steepContrast = 4.5
+                steepMidpoint = 0.731000006
+                maxNormalDeviance = 0.200000346
+                minAltitude = -5
+                maxAltitude = 10000
+                altitudeFadeRange = 10
+                alignToTerrainNormal = True
+                coloredByTerrain = false
+                LODs
+                {
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterhuge2
+                        range = 100
+                        MaterialOverride
+                        {
+                        }
+                    }
+                    LOD
+                    {
+                        model = Parallax_StockScatterTextures/Models/Mun/clusterhuge3
+                        range = 300
+                        MaterialOverride
+                        {
+                        }
+                    }
+                }
+            	    		BiomeBlacklist
+	    		{
+	    			name = Shores
+	    			name = Grasslands
+	    			name = Tundra
+	    			name = Desert
+	    			name = Tropics
+	    			name = Ice Caps
+	    			name = Water
+	    			name = Taiga
+	    			name = Forest
+	    			name = Savanna
+	    		}
+}
+        }
+
+    }
+}

--- a/GameData/RealSolarSystem/Compatibility/Parallax/Parallax.cfg
+++ b/GameData/RealSolarSystem/Compatibility/Parallax/Parallax.cfg
@@ -881,6 +881,21 @@
 			}
 		}
 	}
+	@Body[Kerbin]
+	{
+		%PQS
+		{
+			%Mods
+			{
+				Parallax
+				{
+					subdivisionLevel = 10
+					subdivisionRadius = 700
+					order = 999999
+				}
+			}
+		}
+	}
 	@Body[Venus]
 	{
 		%PQS


### PR DESCRIPTION
Add grass, tree, cactus and rocky scatters to RSS Earth based on Parallax V3.