### PR TITLE
Fix setting timewarp rates

### DIFF
--- a/GameData/RealSolarSystem/Compatibility/TimeWarp.cfg
+++ b/GameData/RealSolarSystem/Compatibility/TimeWarp.cfg
@@ -1,6 +1,6 @@
 // No need to override the user's settings when using BetterTimeWarp or TimeControl
 
-RealSolarSystem:NEEDS[!BetterTimeWarpCont&!TimeControl]
+@REALSOLARSYSTEM:NEEDS[!BetterTimeWarpCont&!TimeControl]
 {
 	timeWarpRates
 	{


### PR DESCRIPTION
This was broken in #311; these settings are supposed to be inside the REALSOLARSYSTEM ConfigNode.