### PR TITLE
Fix water distribution on Mars

### DIFF
--- a/GameData/RealSolarSystem/ResourceConfigs/Water.cfg
+++ b/GameData/RealSolarSystem/ResourceConfigs/Water.cfg
@@ -239,7 +239,7 @@ BIOME_RESOURCE
 	ResourceName = Water
 	ResourceType = 0
 	PlanetName = Mars
-	BiomeName = Midlands
+	BiomeName = Lowlands
 	
 	Distribution
 	{


### PR DESCRIPTION
This water distribution was originally added to represent the findings of Phoenix, which landed in an area corresponding with the Lowlands biome. Even though the original comment from when this was added 10 years ago notes that it corresponds to the Lowlands biome, it has always been improperly set to the Midlands biome. This fixes that.